### PR TITLE
dont overload async in NIOCompat

### DIFF
--- a/Sources/ServiceLauncherNIOCompat/Bridge.swift
+++ b/Sources/ServiceLauncherNIOCompat/Bridge.swift
@@ -20,7 +20,7 @@ extension Lifecycle.Handler {
     ///
     /// - parameters:
     ///    - future: the underlying `EventLoopFuture`
-    public static func async(_ future: @escaping () -> EventLoopFuture<Void>) -> Lifecycle.Handler {
+    public static func eventLoopFuture(_ future: @escaping () -> EventLoopFuture<Void>) -> Lifecycle.Handler {
         return Lifecycle.Handler { callback in
             future().whenComplete { result in
                 switch result {


### PR DESCRIPTION
motiavtion: less overloading == less confusion

changes: rename async in NIOCompat to eventLoopFuture