### PR TITLE
RFC: timeout checks for start and shutdown

### DIFF
--- a/Sources/ServiceLauncher/Lifecycle.swift
+++ b/Sources/ServiceLauncher/Lifecycle.swift
@@ -259,7 +259,7 @@ public class Lifecycle {
         }
 
         var shutdownTask: DispatchWorkItem?
-        var shutdownTimoutTask: DispatchWorkItem?
+        var shutdownTimeoutTask: DispatchWorkItem?
 
         // shutdown
         shutdownTask = DispatchWorkItem {

--- a/Sources/ServiceLauncher/Lifecycle.swift
+++ b/Sources/ServiceLauncher/Lifecycle.swift
@@ -190,7 +190,7 @@ public class Lifecycle {
         }
 
         var startTask: DispatchWorkItem?
-        var startTimoutTask: DispatchWorkItem?
+        var startTimeoutTask: DispatchWorkItem?
 
         // start
         startTask = DispatchWorkItem {
@@ -202,7 +202,7 @@ public class Lifecycle {
                         if startTask?.isCancelled ?? true {
                             return
                         }
-                        startTimoutTask?.cancel()
+                        startTimeoutTask?.cancel()
                         startCompletionHandler(error)
                     }
                 }
@@ -211,7 +211,7 @@ public class Lifecycle {
 
         // start timeout
         startTimeoutTask = DispatchWorkItem {
-            if startTimoutTask?.isCancelled ?? true {
+            if startTimeoutTask?.isCancelled ?? true {
                 return
             }
             startTask?.cancel()
@@ -221,7 +221,7 @@ public class Lifecycle {
         self.logger.info("starting item [\(items[index].label)]")
         // lifecycle code runs on self.queue
         self.queue.async(execute: startTask!)
-        self.queue.asyncAfter(deadline: .now() + configuration.timeout, execute: startTimoutTask!)
+        self.queue.asyncAfter(deadline: .now() + configuration.timeout, execute: startTimeoutTask!)
     }
 
     private func _shutdown(configuration: Configuration, items: [LifecycleItem], callback: @escaping () -> Void) {
@@ -271,7 +271,7 @@ public class Lifecycle {
                         if shutdownTask?.isCancelled ?? true {
                             return
                         }
-                        shutdownTimoutTask?.cancel()
+                        shutdownTimeoutTask?.cancel()
                         shutdownCompletionHandler(error)
                     }
                 }
@@ -279,8 +279,8 @@ public class Lifecycle {
         }
 
         // start timeout
-        shutdownTimoutTask = DispatchWorkItem {
-            if shutdownTimoutTask?.isCancelled ?? true {
+        shutdownTimeoutTask = DispatchWorkItem {
+            if shutdownTimeoutTask?.isCancelled ?? true {
                 return
             }
             shutdownTask?.cancel()
@@ -290,7 +290,7 @@ public class Lifecycle {
         self.logger.info("stopping item [\(items[index].label)]")
         // lifecycle code runs on self.queue
         self.queue.async(execute: shutdownTask!)
-        self.queue.asyncAfter(deadline: .now() + configuration.timeout, execute: shutdownTimoutTask!)
+        self.queue.asyncAfter(deadline: .now() + configuration.timeout, execute: shutdownTimeoutTask!)
     }
 
     private enum State {

--- a/Sources/ServiceLauncher/Lifecycle.swift
+++ b/Sources/ServiceLauncher/Lifecycle.swift
@@ -210,7 +210,7 @@ public class Lifecycle {
         }
 
         // start timeout
-        startTimoutTask = DispatchWorkItem {
+        startTimeoutTask = DispatchWorkItem {
             if startTimoutTask?.isCancelled ?? true {
                 return
             }

--- a/Sources/ServiceLauncher/Lifecycle.swift
+++ b/Sources/ServiceLauncher/Lifecycle.swift
@@ -334,7 +334,7 @@ extension Lifecycle {
         /// Defines if to install a crash signal trap that prints backtraces.
         public let installBacktrace: Bool
 
-        /// Initlizes a `Configuration`.
+        /// Initializes a `Configuration`.
         ///
         /// - parameters:
         ///    - callbackQueue: Defines the `DispatchQueue` on which startup and shutdown handlers are executed.

--- a/Tests/ServiceLauncherTests/LifecycleTests+XCTest.swift
+++ b/Tests/ServiceLauncherTests/LifecycleTests+XCTest.swift
@@ -26,13 +26,16 @@ extension Tests {
     static var allTests: [(String, (Tests) -> () throws -> Void)] {
         return [
             ("testStartThenShutdown", testStartThenShutdown),
-            ("testDispatchQueues", testDispatchQueues),
+            ("testDefaultCallbackQueue", testDefaultCallbackQueue),
+            ("testUserDefinedCallbackQueue", testUserDefinedCallbackQueue),
             ("testShutdownWhileStarting", testShutdownWhileStarting),
             ("testShutdownWhenIdle", testShutdownWhenIdle),
             ("testShutdownWhenShutdown", testShutdownWhenShutdown),
-            ("testShutdownDuringHangingStart", testShutdownDuringHangingStart),
             ("testShutdownErrors", testShutdownErrors),
+            ("testShutdownTimeout", testShutdownTimeout),
             ("testStartupErrors", testStartupErrors),
+            ("testStartupTimeout", testStartupTimeout),
+            ("testShutdownDuringHangingShudown", testShutdownDuringHangingShudown),
             ("testStartAndWait", testStartAndWait),
             ("testBadStartAndWait", testBadStartAndWait),
             ("testShutdownInOrder", testShutdownInOrder),

--- a/Tests/ServiceLauncherTests/LifecycleTests+XCTest.swift
+++ b/Tests/ServiceLauncherTests/LifecycleTests+XCTest.swift
@@ -35,7 +35,7 @@ extension Tests {
             ("testShutdownTimeout", testShutdownTimeout),
             ("testStartupErrors", testStartupErrors),
             ("testStartupTimeout", testStartupTimeout),
-            ("testShutdownDuringHangingShudown", testShutdownDuringHangingShudown),
+            ("testShutdownDuringHangingShutdown", testShutdownDuringHangingShutdown),
             ("testStartAndWait", testStartAndWait),
             ("testBadStartAndWait", testBadStartAndWait),
             ("testShutdownInOrder", testShutdownInOrder),

--- a/Tests/ServiceLauncherTests/LifecycleTests.swift
+++ b/Tests/ServiceLauncherTests/LifecycleTests.swift
@@ -358,7 +358,7 @@ final class Tests: XCTestCase {
         XCTAssertTrue(stopCalls.contains("blocker"))
     }
 
-    func testShutdownDuringHangingShudown() {
+    func testShutdownDuringHangingShutdown() {
         let lifecycle = Lifecycle()
         let blockStartSemaphore = DispatchSemaphore(value: 0)
         var startCalls = [String]()


### PR DESCRIPTION
motivation: cleanly address hanging start and shutdown items

changes:
* listen to timeout per start/shutdown items and raise error
* add tests

open question: 
=> since item start/shutdown may block, top level start/shutdown callbacks happen on Dispatch.global, should we add configuration options for that?
=> default timeout is 5s, sufficient?
=> timeout configuration is the same for start and shutdown, should we have two separate configs? 