### PR TITLE
rename project to SwiftServiceBootstrap

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,10 +1,10 @@
 # Code of Conduct
-To be a truly great community, SwiftServiceLauncher needs to welcome developers from all walks of life,
+To be a truly great community, SwiftServiceBootstrap needs to welcome developers from all walks of life,
 with different backgrounds, and with a wide range of experience. A diverse and friendly
 community will have more great ideas, more unique perspectives, and produce more great 
-code. We will work diligently to make the SwiftServiceLauncher community welcoming to everyone.
+code. We will work diligently to make the SwiftServiceBootstrap community welcoming to everyone.
 
-To give clarity of what is expected of our members, SwiftServiceLauncher has adopted the code of conduct 
+To give clarity of what is expected of our members, SwiftServiceBootstrap has adopted the code of conduct 
 defined by [contributor-covenant.org](https://www.contributor-covenant.org). This document is used across many open source 
 communities, and we think it articulates our values well. The full text is copied below:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ that your contributions are licensed under the Apache 2.0 license (see
 
 Please ensure to specify the following:
 
-* SwiftServiceLauncher commit hash
-* Contextual information (e.g. what you were trying to achieve with SwiftServiceLauncher)
+* SwiftServiceBootstrap commit hash
+* Contextual information (e.g. what you were trying to achieve with SwiftServiceBootstrap)
 * Simplest possible steps to reproduce
   * More complex the steps are, lower the priority will be.
   * A pull request with failing test case is preferred, but it's just fine to paste the test case into the issue description.
@@ -24,10 +24,10 @@ Please ensure to specify the following:
 ### Example
 
 ```
-SwiftServiceLauncher commit hash: 22ec043dc9d24bb011b47ece4f9ee97ee5be2757
+SwiftServiceBootstrap commit hash: 22ec043dc9d24bb011b47ece4f9ee97ee5be2757
 
 Context:
-While load testing my HTTP web server written with SwiftServiceLauncher, I noticed
+While load testing my HTTP web server written with SwiftServiceBootstrap, I noticed
 that one file descriptor is leaked per request.
 
 Steps to reproduce:
@@ -50,7 +50,7 @@ My system has IPv6 disabled.
 
 ## Writing a Patch
 
-A good SwiftServiceLauncher patch is:
+A good SwiftServiceBootstrap patch is:
 
 1. Concise, and contains as few changes as needed to achieve the end result.
 2. Tested, ensuring that any tests provided failed before the patch and pass after it.
@@ -65,7 +65,7 @@ We require that your commit messages match our template. The easiest way to do t
 
 ### Make sure Tests work on Linux
 
-SwiftServiceLauncher uses XCTest to run tests on both macOS and Linux. While the macOS version of XCTest is able to use the Objective-C runtime to discover tests at execution time, the Linux version is not.
+SwiftServiceBootstrap uses XCTest to run tests on both macOS and Linux. While the macOS version of XCTest is able to use the Objective-C runtime to discover tests at execution time, the Linux version is not.
 For this reason, whenever you add new tests **you have to run a script** that generates the hooks needed to run those tests on Linux, or our CI will complain that the tests are not all present on Linux. To do this, merely execute `ruby ./scripts/generate_linux_tests.rb` at the root of the package and check the changes it made.
 
 ## How to contribute your work

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,5 +1,5 @@
 For the purpose of tracking copyright, this is the list of individuals and
-organizations who have contributed source code to SwiftServiceLauncher.
+organizations who have contributed source code to SwiftServiceBootstrap.
 
 For employees of an organization/company where the copyright of work done
 by employees of that company is held by the company itself, only the company
@@ -11,6 +11,8 @@ needs to be listed here.
 
 ### Contributors
 
+- Johannes Weiss <johannesweiss@apple.com>
+- Konrad `ktoso` Malawski <konrad.malawski@project13.pl>
 - Tomer Doron <tomer@apple.com>
 - Yim Lee <yim_lee@apple.com>
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# SwiftServiceLauncher
+# SwiftServiceBootstrap
 
-SwiftServiceLauncher provides a basic mechanism to cleanly start up and shut down the application, freeing resources in order before exiting.
+SwiftServiceBootstrap provides a basic mechanism to cleanly start up and shut down the application, freeing resources in order before exiting.
 It also provides a `Signal`-based shutdown hook, to shutdown on signals like `TERM` or `INT`.
 
-SwiftServiceLauncher was designed with the idea that every application has some startup and shutdown workflow-like-logic which is often sensitive to failure and hard to get right.
+SwiftServiceBootstrap was designed with the idea that every application has some startup and shutdown workflow-like-logic which is often sensitive to failure and hard to get right.
 The library codes this common need in a safe and reusable way that is non-framework specific, and designed to be integrated with any server framework or directly in an application.
 
-This is the beginning of a community-driven open-source project actively seeking contributions, be it code, documentation, or ideas. What SwiftServiceLauncher provides today is covered in the [API docs](https://swift-server.github.io/swift-service-launcher/), but it will continue to evolve with community input.
+This is the beginning of a community-driven open-source project actively seeking contributions, be it code, documentation, or ideas. What SwiftServiceBootstrap provides today is covered in the [API docs](https://swift-server.github.io/swift-service-launcher/), but it will continue to evolve with community input.
 
 ## Getting started
 
-If you have a server-side Swift application or a cross-platform (e.g. Linux, macOS) application, and you would like to manage its startup and shutdown lifecycle, SwiftServiceLauncher is a great idea. Below you will find all you need to know to get started.
+If you have a server-side Swift application or a cross-platform (e.g. Linux, macOS) application, and you would like to manage its startup and shutdown lifecycle, SwiftServiceBootstrap is a great idea. Below you will find all you need to know to get started.
 
 ### Adding the dependency
 
@@ -20,10 +20,10 @@ To add a dependency on the package, declare it in your `Package.swift`:
 .package(url: "https://github.com/swift-server/swift-service-launcher.git", from: "1.0.0"),
 ```
 
-and to your application target, add "SwiftServiceLauncher" to your dependencies:
+and to your application target, add "SwiftServiceBootstrap" to your dependencies:
 
 ```swift
-.target(name: "BestExampleApp", dependencies: ["SwiftServiceLauncher"]),
+.target(name: "BestExampleApp", dependencies: ["SwiftServiceBootstrap"]),
 ```
 
 ###  Defining the lifecycle
@@ -195,7 +195,7 @@ In more complex cases, when signal trapping based shutdown is not appropriate, y
 
 [SwiftNIO](https://github.com/apple/swift-nio) is a popular networking library that among other things provides Future abstraction named `EventLoopFuture`.
 
-SwiftServiceLauncher comes with a compatibility module designed to make managing SwiftNIO based resources easy.
+SwiftServiceBootstrap comes with a compatibility module designed to make managing SwiftNIO based resources easy.
 
 Once you import `ServiceLauncherNIOCompat` module, `Lifecycle.Handler` gains a static helpers named `eventLoopFuture` designed to help simplify the registration call to:
 

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Lifecycle/Locks.swift
+++ b/Sources/Lifecycle/Locks.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) 2020 Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) 2020 Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/LifecycleNIOCompat/Bridge.swift
+++ b/Sources/LifecycleNIOCompat/Bridge.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LifecycleTests/ComponentLifecycleTests.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LifecycleTests/Helpers.swift
+++ b/Tests/LifecycleTests/Helpers.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LifecycleTests/ServiceLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ServiceLifecycleTests+XCTest.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LifecycleTests/ServiceLifecycleTests.swift
+++ b/Tests/LifecycleTests/ServiceLifecycleTests.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/scripts/generate_contributors_list.sh
+++ b/scripts/generate_contributors_list.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftServiceLauncher open source project
+## This source file is part of the SwiftServiceBootstrap open source project
 ##
-## Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLauncher project authors
+## Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+## See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -19,7 +19,7 @@ contributors=$( cd "$here"/.. && git shortlog -es | cut -f2 | sed 's/^/- /' )
 
 cat > "$here/../CONTRIBUTORS.txt" <<- EOF
 	For the purpose of tracking copyright, this is the list of individuals and
-	organizations who have contributed source code to SwiftServiceLauncher.
+	organizations who have contributed source code to SwiftServiceBootstrap.
 
 	For employees of an organization/company where the copyright of work done
 	by employees of that company is held by the company itself, only the company

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftServiceLauncher open source project
+## This source file is part of the SwiftServiceBootstrap open source project
 ##
-## Copyright (c) 2020 Apple Inc. and the SwiftServiceLauncher project authors
+## Copyright (c) 2020 Apple Inc. and the SwiftServiceBootstrap project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+## See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -51,12 +51,12 @@ mkdir -p "$jazzy_dir"
 # prep index
 module_switcher="$jazzy_dir/README.md"
 cat > "$module_switcher" <<"EOF"
-# SwiftServiceLauncher Docs
+# SwiftServiceBootstrap Docs
 
-SwiftServiceLauncher provides a basic mechanism to cleanly start up and shut down the application, freeing resources in order before exiting.
+SwiftServiceBootstrap provides a basic mechanism to cleanly start up and shut down the application, freeing resources in order before exiting.
 It also provides a Signal based shutdown hook, to shutdown on signals like TERM or INT.
 
-SwiftServiceLauncher is non-framework specific, designed to be integrated with any server framework or directly in an application.
+SwiftServiceBootstrap is non-framework specific, designed to be integrated with any server framework or directly in an application.
 
 To get started with SwiftCrypto, [`import ServiceLauncher`](../ServiceLauncher/index.html).
 EOF

--- a/scripts/generate_linux_tests.rb
+++ b/scripts/generate_linux_tests.rb
@@ -34,13 +34,13 @@ def header(fileName)
   string = <<-eos
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftServiceLauncher open source project
+## This source file is part of the SwiftServiceBootstrap open source project
 ##
-## Copyright (c) 2017-2018 Apple Inc. and the SwiftServiceLauncher project authors
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftServiceBootstrap project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+## See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -62,13 +62,13 @@ for language in swift-or-c bash dtrace; do
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceLauncher open source project
+// This source file is part of the SwiftServiceBootstrap open source project
 //
-// Copyright (c) YEARS Apple Inc. and the SwiftServiceLauncher project authors
+// Copyright (c) YEARS Apple Inc. and the SwiftServiceBootstrap project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -81,13 +81,13 @@ EOF
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftServiceLauncher open source project
+## This source file is part of the SwiftServiceBootstrap open source project
 ##
-## Copyright (c) YEARS Apple Inc. and the SwiftServiceLauncher project authors
+## Copyright (c) YEARS Apple Inc. and the SwiftServiceBootstrap project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+## See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -100,13 +100,13 @@ EOF
 #!/usr/sbin/dtrace -q -s
 /*===----------------------------------------------------------------------===*
  *
- *  This source file is part of the SwiftServiceLauncher open source project
+ *  This source file is part of the SwiftServiceBootstrap open source project
  *
- *  Copyright (c) YEARS Apple Inc. and the SwiftServiceLauncher project authors
+ *  Copyright (c) YEARS Apple Inc. and the SwiftServiceBootstrap project authors
  *  Licensed under Apache License v2.0
  *
  *  See LICENSE.txt for license information
- *  See CONTRIBUTORS.txt for the list of SwiftServiceLauncher project authors
+ *  See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
  *
  *  SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
motivation: better name

changes:
* update license headers
* update sanity checks