### PR TITLE
prepare to open source

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,4 @@
 Tomer Doron <tomer@apple.com> <tomer@apple.com>
 Tomer Doron <tomer@apple.com> <tomerd@apple.com>
 Tomer Doron <tomer@apple.com> <tomer.doron@gmail.com>
+Konrad `ktoso` Malawski <konrad_malawski@apple.com> <konrad.malawski@project13.pl>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,10 +1,10 @@
 # Code of Conduct
-To be a truly great community, SwiftServiceBootstrap needs to welcome developers from all walks of life,
+To be a truly great community, SwiftServiceLifecycle needs to welcome developers from all walks of life,
 with different backgrounds, and with a wide range of experience. A diverse and friendly
 community will have more great ideas, more unique perspectives, and produce more great 
-code. We will work diligently to make the SwiftServiceBootstrap community welcoming to everyone.
+code. We will work diligently to make the SwiftServiceLifecycle community welcoming to everyone.
 
-To give clarity of what is expected of our members, SwiftServiceBootstrap has adopted the code of conduct 
+To give clarity of what is expected of our members, SwiftServiceLifecycle has adopted the code of conduct 
 defined by [contributor-covenant.org](https://www.contributor-covenant.org). This document is used across many open source 
 communities, and we think it articulates our values well. The full text is copied below:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ that your contributions are licensed under the Apache 2.0 license (see
 
 Please ensure to specify the following:
 
-* SwiftServiceBootstrap commit hash
-* Contextual information (e.g. what you were trying to achieve with SwiftServiceBootstrap)
+* SwiftServiceLifecycle commit hash
+* Contextual information (e.g. what you were trying to achieve with SwiftServiceLifecycle)
 * Simplest possible steps to reproduce
   * More complex the steps are, lower the priority will be.
   * A pull request with failing test case is preferred, but it's just fine to paste the test case into the issue description.
@@ -24,10 +24,10 @@ Please ensure to specify the following:
 ### Example
 
 ```
-SwiftServiceBootstrap commit hash: 22ec043dc9d24bb011b47ece4f9ee97ee5be2757
+SwiftServiceLifecycle commit hash: 22ec043dc9d24bb011b47ece4f9ee97ee5be2757
 
 Context:
-While load testing my HTTP web server written with SwiftServiceBootstrap, I noticed
+While load testing my HTTP web server written with SwiftServiceLifecycle, I noticed
 that one file descriptor is leaked per request.
 
 Steps to reproduce:
@@ -50,7 +50,7 @@ My system has IPv6 disabled.
 
 ## Writing a Patch
 
-A good SwiftServiceBootstrap patch is:
+A good SwiftServiceLifecycle patch is:
 
 1. Concise, and contains as few changes as needed to achieve the end result.
 2. Tested, ensuring that any tests provided failed before the patch and pass after it.
@@ -65,9 +65,9 @@ We require that your commit messages match our template. The easiest way to do t
 
 ### Make sure Tests work on Linux
 
-SwiftServiceBootstrap uses XCTest to run tests on both macOS and Linux. While the macOS version of XCTest is able to use the Objective-C runtime to discover tests at execution time, the Linux version is not.
+SwiftServiceLifecycle uses XCTest to run tests on both macOS and Linux. While the macOS version of XCTest is able to use the Objective-C runtime to discover tests at execution time, the Linux version is not.
 For this reason, whenever you add new tests **you have to run a script** that generates the hooks needed to run those tests on Linux, or our CI will complain that the tests are not all present on Linux. To do this, merely execute `ruby ./scripts/generate_linux_tests.rb` at the root of the package and check the changes it made.
 
 ## How to contribute your work
 
-Please open a pull request at https://github.com/swift-server/swift-service-bootstrap. Make sure the CI passes, and then wait for code review.
+Please open a pull request at https://github.com/swift-server/swift-service-lifecycle. Make sure the CI passes, and then wait for code review.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,5 +1,5 @@
 For the purpose of tracking copyright, this is the list of individuals and
-organizations who have contributed source code to SwiftServiceBootstrap.
+organizations who have contributed source code to SwiftServiceLifecycle.
 
 For employees of an organization/company where the copyright of work done
 by employees of that company is held by the company itself, only the company
@@ -12,7 +12,7 @@ needs to be listed here.
 ### Contributors
 
 - Johannes Weiss <johannesweiss@apple.com>
-- Konrad `ktoso` Malawski <konrad.malawski@project13.pl>
+- Konrad `ktoso` Malawski <konrad_malawski@apple.com>
 - Tomer Doron <tomer@apple.com>
 - Yim Lee <yim_lee@apple.com>
 

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Lifecycle/Locks.swift
+++ b/Sources/Lifecycle/Locks.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) 2020 Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) 2020 Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/LifecycleNIOCompat/Bridge.swift
+++ b/Sources/LifecycleNIOCompat/Bridge.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LifecycleTests/ComponentLifecycleTests.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LifecycleTests/Helpers.swift
+++ b/Tests/LifecycleTests/Helpers.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LifecycleTests/ServiceLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ServiceLifecycleTests+XCTest.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LifecycleTests/ServiceLifecycleTests.swift
+++ b/Tests/LifecycleTests/ServiceLifecycleTests.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -3,17 +3,17 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-service-bootstrap:16.04-5.1
+    image: swift-service-lifecycle:16.04-5.1
     build:
       args:
         ubuntu_version: "xenial"
         swift_version: "5.1"
 
   test:
-    image: swift-service-bootstrap:16.04-5.1
+    image: swift-service-lifecycle:16.04-5.1
     environment:
       - SANITIZER_ARG=--sanitize=thread
       - SKIP_SIGNAL_TEST=true
 
   shell:
-    image: swift-service-bootstrap:16.04-5.1
+    image: swift-service-lifecycle:16.04-5.1

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -3,14 +3,14 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-service-bootstrap:18.04-5.0
+    image: swift-service-lifecycle:18.04-5.0
     build:
       args:
         ubuntu_version: "bionic"
         swift_version: "5.0"
 
   test:
-    image: swift-service-bootstrap:18.04-5.0
+    image: swift-service-lifecycle:18.04-5.0
 
   shell:
-    image: swift-service-bootstrap:18.04-5.0
+    image: swift-service-lifecycle:18.04-5.0

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -3,14 +3,14 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-service-bootstrap:18.04-5.2
+    image: swift-service-lifecycle:18.04-5.2
     build:
       args:
         ubuntu_version: "bionic"
         swift_version: "5.2"
 
   test:
-    image: swift-service-bootstrap:18.04-5.2
+    image: swift-service-lifecycle:18.04-5.2
 
   shell:
-    image: swift-service-bootstrap:18.04-5.2
+    image: swift-service-lifecycle:18.04-5.2

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -3,13 +3,13 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-service-bootstrap:18.04-5.3
+    image: swift-service-lifecycle:18.04-5.3
     build:
       args:
         base_image: "swiftlang/swift:nightly-bionic"
 
   test:
-    image: swift-service-bootstrap:18.04-5.3
+    image: swift-service-lifecycle:18.04-5.3
 
   shell:
-    image: swift-service-bootstrap:18.04-5.3
+    image: swift-service-lifecycle:18.04-5.3

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,13 +6,13 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-service-bootstrap:default
+    image: swift-service-lifecycle:default
     build:
       context: .
       dockerfile: Dockerfile
 
   common: &common
-    image: swift-service-bootstrap:default
+    image: swift-service-lifecycle:default
     depends_on: [runtime-setup]
     volumes:
       - ~/.ssh:/root/.ssh

--- a/scripts/generate_contributors_list.sh
+++ b/scripts/generate_contributors_list.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftServiceBootstrap open source project
+## This source file is part of the SwiftServiceLifecycle open source project
 ##
-## Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
+## Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLifecycle project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+## See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -19,7 +19,7 @@ contributors=$( cd "$here"/.. && git shortlog -es | cut -f2 | sed 's/^/- /' )
 
 cat > "$here/../CONTRIBUTORS.txt" <<- EOF
 	For the purpose of tracking copyright, this is the list of individuals and
-	organizations who have contributed source code to SwiftServiceBootstrap.
+	organizations who have contributed source code to SwiftServiceLifecycle.
 
 	For employees of an organization/company where the copyright of work done
 	by employees of that company is held by the company itself, only the company

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftServiceBootstrap open source project
+## This source file is part of the SwiftServiceLifecycle open source project
 ##
-## Copyright (c) 2020 Apple Inc. and the SwiftServiceBootstrap project authors
+## Copyright (c) 2020 Apple Inc. and the SwiftServiceLifecycle project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+## See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##

--- a/scripts/generate_linux_tests.rb
+++ b/scripts/generate_linux_tests.rb
@@ -34,13 +34,13 @@ def header(fileName)
   string = <<-eos
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftServiceBootstrap open source project
+## This source file is part of the SwiftServiceLifecycle open source project
 ##
-## Copyright (c) 2017-2018 Apple Inc. and the SwiftServiceBootstrap project authors
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftServiceLifecycle project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+## See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -62,13 +62,13 @@ for language in swift-or-c bash dtrace; do
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftServiceBootstrap open source project
+// This source file is part of the SwiftServiceLifecycle open source project
 //
-// Copyright (c) YEARS Apple Inc. and the SwiftServiceBootstrap project authors
+// Copyright (c) YEARS Apple Inc. and the SwiftServiceLifecycle project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -81,13 +81,13 @@ EOF
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftServiceBootstrap open source project
+## This source file is part of the SwiftServiceLifecycle open source project
 ##
-## Copyright (c) YEARS Apple Inc. and the SwiftServiceBootstrap project authors
+## Copyright (c) YEARS Apple Inc. and the SwiftServiceLifecycle project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+## See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -100,13 +100,13 @@ EOF
 #!/usr/sbin/dtrace -q -s
 /*===----------------------------------------------------------------------===*
  *
- *  This source file is part of the SwiftServiceBootstrap open source project
+ *  This source file is part of the SwiftServiceLifecycle open source project
  *
- *  Copyright (c) YEARS Apple Inc. and the SwiftServiceBootstrap project authors
+ *  Copyright (c) YEARS Apple Inc. and the SwiftServiceLifecycle project authors
  *  Licensed under Apache License v2.0
  *
  *  See LICENSE.txt for license information
- *  See CONTRIBUTORS.txt for the list of SwiftServiceBootstrap project authors
+ *  See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
  *
  *  SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
motivation: cleanup naming and collatoral in preperation to open sourcing the library

changes:
* rename "bootstrap" to "lifecycle"
* contributors list