### PR TITLE
Give markdown rendering of README inside Xcode

### DIFF
--- a/.xcodesamplecode.plist
+++ b/.xcodesamplecode.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>


### PR DESCRIPTION
Same contents as my merged PRs into [swift-numerics](https://github.com/apple/swift-numerics/pull/34), [swift-crypto](https://github.com/apple/swift-crypto/pull/11), [swift-argument-parser](https://github.com/apple/swift-argument-parser/pull/12) and [library-preview](https://github.com/apple/swift-standard-library-preview/pull/1) (establishing precedence 😎), giving proper markdown rendering inside Xcode.

### Motivation:

Reading of markdown becomes easier. Extra important in Swift packages, where the `README` is the first file opened by Xcode when opening said package.

### Modifications:

Just adding the `.xcodesamplecode.plist` file (to the root).

### Result:

As seen in [Apple's ARKit demo (inside `/ARKitExample.xcodeproj/` directory)](https://developer.apple.com/sample-code/wwdc/2017/PlacingObjects.zip)

### Before:
<img width="2272" alt="Before" src="https://user-images.githubusercontent.com/864410/87651754-97ba3f80-c753-11ea-902c-a53af07031aa.png">

### After:
<img width="2272" alt="After" src="https://user-images.githubusercontent.com/864410/87651774-9e48b700-c753-11ea-82f4-74c929627f70.png">

### Drawback
#### ⚠️ Editing is now disabled in Xcode
This effectively **_disables editing markdown files from Xcode_** - or at least I have not found a way of doing so. The "workaround" is just to open markdown files with your favourite alternative text editor, e.g. emacs, VIM, VI, Sublime Text or whatever.

## Meta
Since all linked to PRs above have been merged, feels like folks, in general, agree with me that this gives a much more nice README experience natively inside Xcode. Given that - maybe we ought to make this file part of `swift package init` command? What do you think?
