### PR TITLE
Updated README.md to include logger configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ func register(_ tasks: LifecycleTask...)
 
 `ServiceLifecycle` initializer takes optional `ServiceLifecycle.Configuration` to further refine the `ServiceLifecycle` behavior:
 
+* `logger`: Defines the `Logger` to work with.  By default, `Logger(label: "Lifecycle")` is used.
+
 * `callbackQueue`: Defines the `DispatchQueue` on which startup and shutdown handlers are executed. By default, `DispatchQueue.global` is used.
 
 * `shutdownSignal`: Defines what, if any, signals to trap for invoking shutdown. By default, `INT` and `TERM` are trapped.


### PR DESCRIPTION
The README.md only listed 3 of the 4 Configuration options and did not mention the logging option.  This is important because using swift-service-lifecycle in an existing app which already uses logging can impact that logging unless this configuration item is set.

Added logging option to the configuration discussion.
Placed it first, which is the same as the argument order for ServiceLifecycle.Configuration.