### PR TITLE
setup shutdown hooks on ServiceLifecycle::startAndWait

### DIFF
--- a/Tests/LifecycleTests/ServiceLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ServiceLifecycleTests+XCTest.swift
@@ -28,6 +28,7 @@ extension ServiceLifecycleTests {
             ("testStartThenShutdown", testStartThenShutdown),
             ("testShutdownWithSignal", testShutdownWithSignal),
             ("testStartAndWait", testStartAndWait),
+            ("testStartAndWaitShutdownWithSignal", testStartAndWaitShutdownWithSignal),
             ("testBadStartAndWait", testBadStartAndWait),
             ("testNesting", testNesting),
             ("testNesting2", testNesting2),

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools 
 
 # ruby and jazzy for docs generation
 RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
-RUN gem install jazzy --no-ri --no-rdoc
+RUN if [ "${ubuntu_version}" != "xenial" ] ; then gem install jazzy --no-ri --no-rdoc ; fi
 
 # tools
 RUN mkdir -p $HOME/.tools

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -11,6 +11,8 @@ services:
 
   test:
     image: swift-service-lifecycle:18.04-5.0
-
+    environment:
+      - SKIP_SIGNAL_TEST=true
+  
   shell:
     image: swift-service-lifecycle:18.04-5.0

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -11,6 +11,8 @@ services:
 
   test:
     image: swift-service-lifecycle:18.04-5.2
+    environment:
+      - SKIP_SIGNAL_TEST=true
 
   shell:
     image: swift-service-lifecycle:18.04-5.2

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -10,6 +10,8 @@ services:
 
   test:
     image: swift-service-lifecycle:18.04-5.3
+    environment:
+      - SKIP_SIGNAL_TEST=true
 
   shell:
     image: swift-service-lifecycle:18.04-5.3


### PR DESCRIPTION
motivation: fix startAndWait to work as advertised

changes:
* extract shutdown setup to a func and call it from both start and startAndWait
* add test
* fix api doc