### PR TITLE
Remove unused macOS(.v10_12) platform requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,6 @@ import PackageDescription
 
 let package = Package(
     name: "swift-service-lifecycle",
-    platforms: [
-        .macOS(.v10_12),
-    ],
     products: [
         .library(name: "Lifecycle", targets: ["Lifecycle"]),
         .library(name: "LifecycleNIOCompat", targets: ["LifecycleNIOCompat"]),


### PR DESCRIPTION
### Motivation

The less requirements a project has the better. Currently `swift-server-lifecycle` requires that macOS is at least at version 10.12.

### Changes

Since the mentioned requirement is not needed at all, it can be removed.

### Result

Less SwiftPM pain. Easier to integrate for downstream repos, without adding new requirements.