### PR TITLE
abstract registration function into a protocol

### DIFF
--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -196,7 +196,7 @@ extension ServiceLifecycle {
     }
 }
 
-extension ServiceLifecycle: LifecycleTasksConainer {
+extension ServiceLifecycle: LifecycleTasksContainer {
     public func register(_ tasks: [LifecycleTask]) {
         self.underlying.register(tasks)
     }
@@ -451,7 +451,7 @@ public class ComponentLifecycle: LifecycleTask {
     }
 }
 
-extension ComponentLifecycle: LifecycleTasksConainer {
+extension ComponentLifecycle: LifecycleTasksContainer {
     public func register(_ tasks: [LifecycleTask]) {
         self.stateLock.withLock {
             guard case .idle = self.state else {
@@ -465,7 +465,7 @@ extension ComponentLifecycle: LifecycleTasksConainer {
 }
 
 /// A container of `LifecycleTask`, used to register additional `LifecycleTask`
-public protocol LifecycleTasksConainer {
+public protocol LifecycleTasksContainer {
     /// Adds a `LifecycleTask` to a `LifecycleTasks` collection.
     ///
     /// - parameters:
@@ -473,7 +473,7 @@ public protocol LifecycleTasksConainer {
     func register(_ tasks: [LifecycleTask])
 }
 
-extension LifecycleTasksConainer {
+extension LifecycleTasksContainer {
     /// Adds a `LifecycleTask` to a `LifecycleTasks` collection.
     ///
     /// - parameters:

--- a/Tests/LifecycleTests/ComponentLifecycleTests.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests.swift
@@ -43,16 +43,16 @@ final class ComponentLifecycleTests: XCTestCase {
 
         let items = (1 ... Int.random(in: 10 ... 20)).map { index -> LifecycleTask in
             let id = "item-\(index)"
-            return LifecycleTaskImpl(label: id,
-                                     start: .sync {
-                                         dispatchPrecondition(condition: .onQueue(.global()))
-                                         startCalls.append(id)
-                                     },
-                                     shutdown: .sync {
-                                         dispatchPrecondition(condition: .onQueue(.global()))
-                                         XCTAssertTrue(startCalls.contains(id))
-                                         stopCalls.append(id)
-                                     })
+            return _LifecycleTask(label: id,
+                                  start: .sync {
+                                      dispatchPrecondition(condition: .onQueue(.global()))
+                                      startCalls.append(id)
+                                  },
+                                  shutdown: .sync {
+                                      dispatchPrecondition(condition: .onQueue(.global()))
+                                      XCTAssertTrue(startCalls.contains(id))
+                                      stopCalls.append(id)
+                                 })
         }
         lifecycle.register(items)
 
@@ -81,16 +81,16 @@ final class ComponentLifecycleTests: XCTestCase {
 
         let items = (1 ... Int.random(in: 10 ... 20)).map { index -> LifecycleTask in
             let id = "item-\(index)"
-            return LifecycleTaskImpl(label: id,
-                                     start: .sync {
-                                         dispatchPrecondition(condition: .onQueue(testQueue))
-                                         startCalls.append(id)
-                                     },
-                                     shutdown: .sync {
-                                         dispatchPrecondition(condition: .onQueue(testQueue))
-                                         XCTAssertTrue(startCalls.contains(id))
-                                         stopCalls.append(id)
-                                     })
+            return _LifecycleTask(label: id,
+                                  start: .sync {
+                                      dispatchPrecondition(condition: .onQueue(testQueue))
+                                      startCalls.append(id)
+                                  },
+                                  shutdown: .sync {
+                                      dispatchPrecondition(condition: .onQueue(testQueue))
+                                      XCTAssertTrue(startCalls.contains(id))
+                                      stopCalls.append(id)
+                                 })
         }
         lifecycle.register(items)
 

--- a/Tests/LifecycleTests/ComponentLifecycleTests.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests.swift
@@ -43,16 +43,16 @@ final class ComponentLifecycleTests: XCTestCase {
 
         let items = (1 ... Int.random(in: 10 ... 20)).map { index -> LifecycleTask in
             let id = "item-\(index)"
-            return ComponentLifecycle.Task(label: id,
-                                           start: .sync {
-                                               dispatchPrecondition(condition: .onQueue(.global()))
-                                               startCalls.append(id)
-                                           },
-                                           shutdown: .sync {
-                                               dispatchPrecondition(condition: .onQueue(.global()))
-                                               XCTAssertTrue(startCalls.contains(id))
-                                               stopCalls.append(id)
-                                           })
+            return LifecycleTaskImpl(label: id,
+                                     start: .sync {
+                                         dispatchPrecondition(condition: .onQueue(.global()))
+                                         startCalls.append(id)
+                                     },
+                                     shutdown: .sync {
+                                         dispatchPrecondition(condition: .onQueue(.global()))
+                                         XCTAssertTrue(startCalls.contains(id))
+                                         stopCalls.append(id)
+                                     })
         }
         lifecycle.register(items)
 
@@ -81,16 +81,16 @@ final class ComponentLifecycleTests: XCTestCase {
 
         let items = (1 ... Int.random(in: 10 ... 20)).map { index -> LifecycleTask in
             let id = "item-\(index)"
-            return ComponentLifecycle.Task(label: id,
-                                           start: .sync {
-                                               dispatchPrecondition(condition: .onQueue(testQueue))
-                                               startCalls.append(id)
-                                           },
-                                           shutdown: .sync {
-                                               dispatchPrecondition(condition: .onQueue(testQueue))
-                                               XCTAssertTrue(startCalls.contains(id))
-                                               stopCalls.append(id)
-                                           })
+            return LifecycleTaskImpl(label: id,
+                                     start: .sync {
+                                         dispatchPrecondition(condition: .onQueue(testQueue))
+                                         startCalls.append(id)
+                                     },
+                                     shutdown: .sync {
+                                         dispatchPrecondition(condition: .onQueue(testQueue))
+                                         XCTAssertTrue(startCalls.contains(id))
+                                         stopCalls.append(id)
+                                     })
         }
         lifecycle.register(items)
 


### PR DESCRIPTION
motivation: allow libraries that want to expose the lifecycle so that downstream code could register additional items to do so regardless of the lifecycle backend

changes: abstract registration function into a protocol and conform ComponentLifecycle and ServiceLifecycle to it