### PR TITLE
add semantics for stopping tasks that have no start handler

### DIFF
--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -256,11 +256,8 @@ public class ComponentLifecycle: LifecycleTask {
     private let logger: Logger
     internal let shutdownGroup = DispatchGroup()
 
-    private var state = State.idle
+    private var state = State.idle([])
     private let stateLock = Lock()
-
-    private var tasks = [LifecycleTask]()
-    private let tasksLock = Lock()
 
     /// Creates a `ComponentLifecycle` instance.
     ///
@@ -289,7 +286,9 @@ public class ComponentLifecycle: LifecycleTask {
     ///    - on: `DispatchQueue` to run the handlers callback  on
     ///    - callback: The handler which is called after the start operation completes. The parameter will be `nil` on success and contain the `Error` otherwise.
     public func start(on queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) {
-        let tasks = self.tasksLock.withLock { self.tasks }
+        guard case .idle(let tasks) = (self.stateLock.withLock { self.state }) else {
+            preconditionFailure("invalid state, \(self.state)")
+        }
         self._start(on: queue, tasks: tasks, callback: callback)
     }
 
@@ -325,11 +324,17 @@ public class ComponentLifecycle: LifecycleTask {
 
         self.stateLock.lock()
         switch self.state {
-        case .idle:
+        case .idle(let tasks) where tasks.isEmpty:
             self.state = .shutdown(nil)
             self.stateLock.unlock()
             defer { self.shutdownGroup.leave() }
             callback(nil)
+        case .idle(let tasks):
+            self.stateLock.unlock()
+            let queue = DispatchQueue.global() // is this the best we can do?
+            setupShutdownListener(queue)
+            let stoppable = tasks.filter { $0.shutdownIfNotStarted }
+            self._shutdown(on: queue, tasks: stoppable, callback: self.shutdownGroup.leave)
         case .shutdown:
             self.stateLock.unlock()
             self.log(level: .warning, "already shutdown")
@@ -342,7 +347,6 @@ public class ComponentLifecycle: LifecycleTask {
             self.stateLock.unlock()
             setupShutdownListener(queue)
         case .started(let queue, let tasks):
-            self.state = .shuttingDown(queue)
             self.stateLock.unlock()
             setupShutdownListener(queue)
             self._shutdown(on: queue, tasks: tasks, callback: self.shutdownGroup.leave)
@@ -462,7 +466,7 @@ public class ComponentLifecycle: LifecycleTask {
     }
 
     private enum State {
-        case idle
+        case idle([LifecycleTask])
         case starting(DispatchQueue)
         case started(DispatchQueue, [LifecycleTask])
         case shuttingDown(DispatchQueue)
@@ -473,12 +477,10 @@ public class ComponentLifecycle: LifecycleTask {
 extension ComponentLifecycle: LifecycleTasksContainer {
     public func register(_ tasks: [LifecycleTask]) {
         self.stateLock.withLock {
-            guard case .idle = self.state else {
+            guard case .idle(let existing) = self.state else {
                 preconditionFailure("invalid state, \(self.state)")
             }
-        }
-        self.tasksLock.withLock {
-            self.tasks.append(contentsOf: tasks)
+            self.state = .idle(existing + tasks)
         }
     }
 }

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -44,14 +44,18 @@ public struct LifecycleHandler {
     private let body: (@escaping (Error?) -> Void) -> Void
     internal let noop: Bool
 
+    private init(_ callback: @escaping (@escaping (Error?) -> Void) -> Void, noop: Bool) {
+        self.body = callback
+        self.noop = noop
+    }
+
     /// Initialize a `LifecycleHandler` based on a completion handler.
     ///
     /// - parameters:
     ///    - callback: the underlying completion handler
     ///    - noop: the underlying completion handler is a no-op
-    public init(_ callback: @escaping (@escaping (Error?) -> Void) -> Void, noop: Bool = false) {
-        self.body = callback
-        self.noop = noop
+    public init(_ callback: @escaping (@escaping (Error?) -> Void) -> Void) {
+        self.init(callback, noop: false)
     }
 
     /// Asynchronous `LifecycleHandler` based on a completion handler.
@@ -67,14 +71,14 @@ public struct LifecycleHandler {
     /// - parameters:
     ///    - body: the underlying function
     public static func sync(_ body: @escaping () throws -> Void) -> LifecycleHandler {
-        return LifecycleHandler({ completionHandler in
+        return LifecycleHandler { completionHandler in
             do {
                 try body()
                 completionHandler(nil)
             } catch {
                 completionHandler(error)
             }
-        })
+        }
     }
 
     /// Noop `LifecycleHandler`.

--- a/Sources/LifecycleNIOCompat/Bridge.swift
+++ b/Sources/LifecycleNIOCompat/Bridge.swift
@@ -21,7 +21,7 @@ extension LifecycleHandler {
     /// - parameters:
     ///    - future: function returning the underlying `EventLoopFuture`
     public static func eventLoopFuture(_ future: @escaping () -> EventLoopFuture<Void>) -> LifecycleHandler {
-        return LifecycleHandler { callback in
+        return LifecycleHandler({ callback in
             future().whenComplete { result in
                 switch result {
                 case .success:
@@ -30,7 +30,7 @@ extension LifecycleHandler {
                     callback(error)
                 }
             }
-        }
+        })
     }
 
     /// `Lifecycle.Handler` that cancels a `RepeatedTask`.

--- a/Sources/LifecycleNIOCompat/Bridge.swift
+++ b/Sources/LifecycleNIOCompat/Bridge.swift
@@ -47,13 +47,13 @@ extension LifecycleHandler {
     }
 }
 
-extension ServiceLifecycle {
+extension ComponentLifecycle {
     /// Starts the provided `LifecycleItem` array.
     /// Startup is performed in the order of items provided.
     ///
     /// - parameters:
     ///    - eventLoop: The `eventLoop` which is used to generate the `EventLoopFuture` that is returned. After the start the future is fulfilled:
-    func start(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    public func start(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
         let promise = eventLoop.makePromise(of: Void.self)
         self.start { error in
             if let error = error {

--- a/Sources/LifecycleNIOCompat/Bridge.swift
+++ b/Sources/LifecycleNIOCompat/Bridge.swift
@@ -21,7 +21,7 @@ extension LifecycleHandler {
     /// - parameters:
     ///    - future: function returning the underlying `EventLoopFuture`
     public static func eventLoopFuture(_ future: @escaping () -> EventLoopFuture<Void>) -> LifecycleHandler {
-        return LifecycleHandler({ callback in
+        return LifecycleHandler { callback in
             future().whenComplete { result in
                 switch result {
                 case .success:
@@ -30,7 +30,7 @@ extension LifecycleHandler {
                     callback(error)
                 }
             }
-        })
+        }
     }
 
     /// `Lifecycle.Handler` that cancels a `RepeatedTask`.

--- a/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
@@ -57,7 +57,6 @@ extension ComponentLifecycleTests {
             ("testNOOPHandlers", testNOOPHandlers),
             ("testShutdownOnlyStarted", testShutdownOnlyStarted),
             ("testShutdownWhenStartFailedIfAsked", testShutdownWhenStartFailedIfAsked),
-            ("testShutdownWhenIdleIfAsked", testShutdownWhenIdleIfAsked),
         ]
     }
 }

--- a/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
@@ -56,7 +56,8 @@ extension ComponentLifecycleTests {
             ("testExternalState", testExternalState),
             ("testNOOPHandlers", testNOOPHandlers),
             ("testShutdownOnlyStarted", testShutdownOnlyStarted),
-            ("testShutdownIfNotStartedWhenAsked", testShutdownIfNotStartedWhenAsked),
+            ("testShutdownWhenStartFailedIfAsked", testShutdownWhenStartFailedIfAsked),
+            ("testShutdownWhenIdleIfAsked", testShutdownWhenIdleIfAsked),
         ]
     }
 }

--- a/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
@@ -54,6 +54,9 @@ extension ComponentLifecycleTests {
             ("testNIOFailure", testNIOFailure),
             ("testInternalState", testInternalState),
             ("testExternalState", testExternalState),
+            ("testNOOPHandlers", testNOOPHandlers),
+            ("testShutdownOnlyStarted", testShutdownOnlyStarted),
+            ("testShutdownIfNotStartedWhenAsked", testShutdownIfNotStartedWhenAsked),
         ]
     }
 }

--- a/Tests/LifecycleTests/ComponentLifecycleTests.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests.swift
@@ -974,62 +974,12 @@ final class ComponentLifecycleTests: XCTestCase {
         lifecycle.register(label: item5.label, start: .none, shutdown: .sync(item5.shutdown))
 
         let item6 = DestructionSensitive(label: "6", sempahore: sempahore)
-        lifecycle.register(label: item6.label, shutdownIfNotStarted: true, start: .sync(item6.start), shutdown: .sync(item6.shutdown))
+        lifecycle.register(_LifecycleTask(label: item6.label, shutdownIfNotStarted: true, start: .sync(item6.start), shutdown: .sync(item6.shutdown)))
 
         lifecycle.start { error in
             XCTAssertNotNil(error, "expecting error")
             lifecycle.shutdown()
         }
-        lifecycle.wait()
-
-        XCTAssertEqual(.success, sempahore.wait(timeout: .now() + 1))
-    }
-
-    func testShutdownWhenIdleIfAsked() {
-        class DestructionSensitive {
-            let label: String
-            let sempahore: DispatchSemaphore
-            var state = State.idle
-
-            deinit {
-                XCTAssertEqual(self.state, .shutdown, "\"\(self.label)\" should be shutdown")
-                self.sempahore.signal()
-            }
-
-            init(label: String, sempahore: DispatchSemaphore) {
-                self.label = label
-                self.sempahore = sempahore
-            }
-
-            func start() throws {
-                self.state = .started
-            }
-
-            func shutdown() throws {
-                self.state = .shutdown
-            }
-
-            enum State {
-                case idle
-                case started
-                case shutdown
-                case error
-            }
-        }
-
-        let sempahore = DispatchSemaphore(value: 3)
-        let lifecycle = ServiceLifecycle(configuration: .init(shutdownSignal: nil))
-
-        let item1 = DestructionSensitive(label: "1", sempahore: sempahore)
-        lifecycle.registerShutdown(label: item1.label, .sync(item1.shutdown))
-
-        let item2 = DestructionSensitive(label: "2", sempahore: sempahore)
-        lifecycle.register(label: item2.label, start: .none, shutdown: .sync(item2.shutdown))
-
-        let item3 = DestructionSensitive(label: "3", sempahore: sempahore)
-        lifecycle.register(label: item3.label, shutdownIfNotStarted: true, start: .sync(item3.start), shutdown: .sync(item3.shutdown))
-
-        lifecycle.shutdown()
         lifecycle.wait()
 
         XCTAssertEqual(.success, sempahore.wait(timeout: .now() + 1))

--- a/Tests/LifecycleTests/ComponentLifecycleTests.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests.swift
@@ -851,7 +851,7 @@ final class ComponentLifecycleTests: XCTestCase {
         let async = LifecycleHandler.async { _ in }
         XCTAssertEqual(async.noop, false)
 
-        let custom = LifecycleHandler({ _ in })
+        let custom = LifecycleHandler { _ in }
         XCTAssertEqual(custom.noop, false)
     }
 

--- a/Tests/LifecycleTests/ComponentLifecycleTests.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests.swift
@@ -82,6 +82,7 @@ final class ComponentLifecycleTests: XCTestCase {
         let items = (1 ... Int.random(in: 10 ... 20)).map { index -> LifecycleTask in
             let id = "item-\(index)"
             return _LifecycleTask(label: id,
+                                  shutdownIfNotStarted: false,
                                   start: .sync {
                                       dispatchPrecondition(condition: .onQueue(testQueue))
                                       startCalls.append(id)
@@ -838,5 +839,149 @@ final class ComponentLifecycleTests: XCTestCase {
         }
         lifecycle.wait()
         XCTAssertEqual(state, .shutdown, "expected item to be shutdown, but \(state)")
+    }
+
+    func testNOOPHandlers() {
+        let none = LifecycleHandler.none
+        XCTAssertEqual(none.noop, true)
+
+        let sync = LifecycleHandler.sync {}
+        XCTAssertEqual(sync.noop, false)
+
+        let async = LifecycleHandler.async { _ in }
+        XCTAssertEqual(async.noop, false)
+
+        let custom = LifecycleHandler({ _ in })
+        XCTAssertEqual(custom.noop, false)
+    }
+
+    func testShutdownOnlyStarted() {
+        class Item {
+            let label: String
+            let sempahore: DispatchSemaphore
+            let failStart: Bool
+            let exptectedState: State
+            var state = State.idle
+
+            deinit {
+                XCTAssertEqual(self.state, self.exptectedState, "\"\(self.label)\" should be \(self.exptectedState)")
+                self.sempahore.signal()
+            }
+
+            init(label: String, failStart: Bool, exptectedState: State, sempahore: DispatchSemaphore) {
+                self.label = label
+                self.failStart = failStart
+                self.exptectedState = exptectedState
+                self.sempahore = sempahore
+            }
+
+            func start() throws {
+                self.state = .started
+                if self.failStart {
+                    self.state = .error
+                    throw InitError()
+                }
+            }
+
+            func shutdown() throws {
+                self.state = .shutdown
+            }
+
+            enum State {
+                case idle
+                case started
+                case shutdown
+                case error
+            }
+
+            struct InitError: Error {}
+        }
+
+        let count = Int.random(in: 10 ..< 20)
+        let sempahore = DispatchSemaphore(value: count)
+        let lifecycle = ServiceLifecycle(configuration: .init(shutdownSignal: nil))
+
+        for index in 0 ..< count {
+            let item = Item(label: "\(index)", failStart: index == count / 2, exptectedState: index <= count / 2 ? .shutdown : .idle, sempahore: sempahore)
+            lifecycle.register(label: item.label, start: .sync(item.start), shutdown: .sync(item.shutdown))
+        }
+
+        lifecycle.start { error in
+            XCTAssertNotNil(error, "expecting error")
+            lifecycle.shutdown()
+        }
+        lifecycle.wait()
+
+        XCTAssertEqual(.success, sempahore.wait(timeout: .now() + 1))
+    }
+
+    func testShutdownIfNotStartedWhenAsked() {
+        class DestructionSensitive {
+            let label: String
+            let failStart: Bool
+            let sempahore: DispatchSemaphore
+            var state = State.idle
+
+            deinit {
+                XCTAssertEqual(self.state, .shutdown, "\"\(self.label)\" should be shutdown")
+                self.sempahore.signal()
+            }
+
+            init(label: String, failStart: Bool = false, sempahore: DispatchSemaphore) {
+                self.label = label
+                self.failStart = failStart
+                self.sempahore = sempahore
+            }
+
+            func start() throws {
+                self.state = .started
+                if self.failStart {
+                    self.state = .error
+                    throw InitError()
+                }
+            }
+
+            func shutdown() throws {
+                self.state = .shutdown
+            }
+
+            enum State {
+                case idle
+                case started
+                case shutdown
+                case error
+            }
+
+            struct InitError: Error {}
+        }
+
+        let sempahore = DispatchSemaphore(value: 6)
+        let lifecycle = ServiceLifecycle(configuration: .init(shutdownSignal: nil))
+
+        let item1 = DestructionSensitive(label: "1", sempahore: sempahore)
+        lifecycle.register(label: item1.label, start: .sync(item1.start), shutdown: .sync(item1.shutdown))
+
+        let item2 = DestructionSensitive(label: "2", sempahore: sempahore)
+        lifecycle.registerShutdown(label: item2.label, .sync(item2.shutdown))
+
+        let item3 = DestructionSensitive(label: "3", failStart: true, sempahore: sempahore)
+        lifecycle.register(label: item3.label, start: .sync(item3.start), shutdown: .sync(item3.shutdown))
+
+        let item4 = DestructionSensitive(label: "4", sempahore: sempahore)
+        lifecycle.registerShutdown(label: item4.label, .sync(item4.shutdown))
+
+        let item5 = DestructionSensitive(label: "5", sempahore: sempahore)
+        lifecycle.register(label: item5.label, start: .none, shutdown: .sync(item5.shutdown))
+
+        let item6 = DestructionSensitive(label: "6", sempahore: sempahore)
+        lifecycle.register(label: item6.label, shutdownIfNotStarted: true, start: .sync(item3.start), shutdown: .sync(item6.shutdown))
+
+        lifecycle.start { error in
+            XCTAssertNotNil(error, "expecting error")
+            lifecycle.shutdown()
+        }
+        lifecycle.wait()
+
+        XCTAssertEqual(.success, sempahore.wait(timeout: .now() + 1))
     }
 }


### PR DESCRIPTION
motivation: address shutdown for tasks which allocate resources on construction. before this change, only tasks that have been started are shutdown, this creates an issue when the resources are allocated on construction since the item may not get started at all (for example due to error in earlier task) and thus will never be shutdown and the resources will leak.

changes: add semantics to request shutdown even if not started, and assume this se semantics when registering with `start: .none` or with `registerShutdown`