### PR TITLE
Add support for HUP, USR1, USR2 signals

### DIFF
--- a/.xcodesamplecode.plist
+++ b/.xcodesamplecode.plist
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<array/>
-</plist>

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -176,14 +176,16 @@ extension ServiceLifecycle {
     /// - parameters:
     ///    - signal: The signal to trap.
     ///    - handler: closure to invoke when the signal is captured.
+    ///    - on: DispatchQueue to run the signal handler on (default global dispatch queue)
+    ///    - cancelAfterTrap: Defaults to false, which means the signal handler can be run multiple times. If true, the DispatchSignalSource will be cancelled after being trapped once.
     /// - returns: a `DispatchSourceSignal` for the given trap. The source must be cancelled by the caller.
     public static func trap(signal sig: Signal, handler: @escaping (Signal) -> Void, on queue: DispatchQueue = .global(), cancelAfterTrap: Bool = false) -> DispatchSourceSignal {
         let signalSource = DispatchSource.makeSignalSource(signal: sig.rawValue, queue: queue)
         signal(sig.rawValue, SIG_IGN)
         signalSource.setEventHandler(handler: {
-	    if (cancelAfterTrap) {
-	        signalSource.cancel()
-	    }
+        if (cancelAfterTrap) {
+            signalSource.cancel()
+        }
             handler(sig)
         })
         signalSource.resume()
@@ -196,10 +198,10 @@ extension ServiceLifecycle {
 
         public static let TERM = Signal(rawValue: SIGTERM)
         public static let INT = Signal(rawValue: SIGINT)
-	public static let USR1 = Signal(rawValue: SIGUSR1)
+        public static let USR1 = Signal(rawValue: SIGUSR1)
         public static let USR2 = Signal(rawValue: SIGUSR2)
         public static let HUP = Signal(rawValue: SIGHUP)
-	
+
         // for testing
         internal static let ALRM = Signal(rawValue: SIGALRM)
 

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -183,9 +183,9 @@ extension ServiceLifecycle {
         let signalSource = DispatchSource.makeSignalSource(signal: sig.rawValue, queue: queue)
         signal(sig.rawValue, SIG_IGN)
         signalSource.setEventHandler(handler: {
-        if (cancelAfterTrap) {
-            signalSource.cancel()
-        }
+            if (cancelAfterTrap) {
+                signalSource.cancel()
+            }
             handler(sig)
         })
         signalSource.resume()
@@ -215,7 +215,6 @@ extension ServiceLifecycle {
             case Signal.USR2: result += "USR2, "
             case Signal.HUP: result += "HUP, "
             default: () // ok to ignore
-	    
             }
             result += "rawValue: \(self.rawValue))"
             return result

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -504,8 +504,8 @@ extension LifecycleTasksContainer {
     ///    - label: label of the item, useful for debugging.
     ///    - start: `Handler` to perform the startup.
     ///    - shutdown: `Handler` to perform the shutdown.
-    public func register(label: String, start: LifecycleHandler, shutdown: LifecycleHandler) {
-        self.register(_LifecycleTask(label: label, shutdownIfNotStarted: nil, start: start, shutdown: shutdown))
+    public func register(label: String, start: LifecycleHandler, shutdown: LifecycleHandler, shutdownIfNotStarted: Bool? = nil) {
+        self.register(_LifecycleTask(label: label, shutdownIfNotStarted: shutdownIfNotStarted, start: start, shutdown: shutdown))
     }
 
     /// Adds a `LifecycleTask` to a `LifecycleTasks` collection.

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -158,7 +158,7 @@ public struct ServiceLifecycle {
             let signalSource = ServiceLifecycle.trap(signal: signal, handler: { signal in
                 self.log("intercepted signal: \(signal)")
                 self.shutdown()
-            })
+            }, cancelAfterTrap: true)
             self.underlying.shutdownGroup.notify(queue: .global()) {
                 signalSource.cancel()
             }
@@ -177,7 +177,7 @@ extension ServiceLifecycle {
     ///    - signal: The signal to trap.
     ///    - handler: closure to invoke when the signal is captured.
     /// - returns: a `DispatchSourceSignal` for the given trap. The source must be cancelled by the caller.
-    public static func trap(signal sig: Signal, handler: @escaping (Signal) -> Void, on queue: DispatchQueue = .global(), cancelAfterTrap: Bool = true) -> DispatchSourceSignal {
+    public static func trap(signal sig: Signal, handler: @escaping (Signal) -> Void, on queue: DispatchQueue = .global(), cancelAfterTrap: Bool = false) -> DispatchSourceSignal {
         let signalSource = DispatchSource.makeSignalSource(signal: sig.rawValue, queue: queue)
         signal(sig.rawValue, SIG_IGN)
         signalSource.setEventHandler(handler: {

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -194,6 +194,9 @@ extension ServiceLifecycle {
 
         public static let TERM = Signal(rawValue: SIGTERM)
         public static let INT = Signal(rawValue: SIGINT)
+	public static let USR1 = Signal(rawValue: SIGUSR1)
+        public static let USR2 = Signal(rawValue: SIGUSR2)
+
         // for testing
         internal static let ALRM = Signal(rawValue: SIGALRM)
 

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -198,7 +198,8 @@ extension ServiceLifecycle {
         public static let INT = Signal(rawValue: SIGINT)
 	public static let USR1 = Signal(rawValue: SIGUSR1)
         public static let USR2 = Signal(rawValue: SIGUSR2)
-
+        public static let HUP = Signal(rawValue: SIGHUP)
+	
         // for testing
         internal static let ALRM = Signal(rawValue: SIGALRM)
 
@@ -208,7 +209,11 @@ extension ServiceLifecycle {
             case Signal.TERM: result += "TERM, "
             case Signal.INT: result += "INT, "
             case Signal.ALRM: result += "ALRM, "
-            default: () // ok to ignore
+            case Signal.USR1: result += "USR1, "
+            case Signal.USR2: result += "USR2, "
+            case Signal.HUP: result += "HUP, "
+
+        default: () // ok to ignore
             }
             result += "rawValue: \(self.rawValue))"
             return result

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -177,11 +177,13 @@ extension ServiceLifecycle {
     ///    - signal: The signal to trap.
     ///    - handler: closure to invoke when the signal is captured.
     /// - returns: a `DispatchSourceSignal` for the given trap. The source must be cancelled by the caller.
-    public static func trap(signal sig: Signal, handler: @escaping (Signal) -> Void, on queue: DispatchQueue = .global()) -> DispatchSourceSignal {
+    public static func trap(signal sig: Signal, handler: @escaping (Signal) -> Void, on queue: DispatchQueue = .global(), cancelAfterTrap: Bool = true) -> DispatchSourceSignal {
         let signalSource = DispatchSource.makeSignalSource(signal: sig.rawValue, queue: queue)
         signal(sig.rawValue, SIG_IGN)
         signalSource.setEventHandler(handler: {
-            signalSource.cancel()
+	    if (cancelAfterTrap) {
+	        signalSource.cancel()
+	    }
             handler(sig)
         })
         signalSource.resume()

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -183,7 +183,7 @@ extension ServiceLifecycle {
         let signalSource = DispatchSource.makeSignalSource(signal: sig.rawValue, queue: queue)
         signal(sig.rawValue, SIG_IGN)
         signalSource.setEventHandler(handler: {
-            if (cancelAfterTrap) {
+            if cancelAfterTrap {
                 signalSource.cancel()
             }
             handler(sig)

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -214,8 +214,8 @@ extension ServiceLifecycle {
             case Signal.USR1: result += "USR1, "
             case Signal.USR2: result += "USR2, "
             case Signal.HUP: result += "HUP, "
-
-        default: () // ok to ignore
+            default: () // ok to ignore
+	    
             }
             result += "rawValue: \(self.rawValue))"
             return result


### PR DESCRIPTION
Motivation:
Some servers want to support customised handling of signals except for simply shutting down.

Added support for USR1/USR2 signal traps for (#64) - extended trap() signature with one more optional argument to allow for signal handler to be run multiple times with usage like this:

```
let alrmDispatchSourceSignal = ServiceLifecycle.trap(signal: ServiceLifecycle.Signal.USR1, handler: { signal in
	    print("signal \(signal)")
	}, cancelAfterTrap: false)```

Existing usage of .trap() is unaffected.

Possibly additional signals (HUP?) should be added too.

Changes:
Added USR1/USR2 to Signal struct to allow for trapping them.
Changed .trap() signature to allow for signal handlers to be run multiple times without reregistration.
