### PR TITLE
Express backtrace as a LifecycleTask

### DIFF
--- a/.xcodesamplecode.plist
+++ b/.xcodesamplecode.plist
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<array/>
-</plist>

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -504,8 +504,8 @@ extension LifecycleTasksContainer {
     ///    - label: label of the item, useful for debugging.
     ///    - start: `Handler` to perform the startup.
     ///    - shutdown: `Handler` to perform the shutdown.
-    public func register(label: String, start: LifecycleHandler, shutdown: LifecycleHandler) {
-        self.register(_LifecycleTask(label: label, shutdownIfNotStarted: nil, start: start, shutdown: shutdown))
+    public func register(label: String, start: LifecycleHandler, shutdown: LifecycleHandler, shutdownIfNotStarted: Bool? = nil) {
+        self.register(_LifecycleTask(label: label, shutdownIfNotStarted: shutdownIfNotStarted, start: start, shutdown: shutdown))
     }
 
     /// Adds a `LifecycleTask` to a `LifecycleTasks` collection.

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -116,8 +116,9 @@ public struct ServiceLifecycle {
         self.underlying = ComponentLifecycle(label: self.configuration.label, logger: self.configuration.logger)
         // setup backtrace trap as soon as possible
         if configuration.installBacktrace {
-            self.log("installing backtrace")
-            Backtrace.install()
+            self.register(label: "Backtrace",
+                          start: .sync(self.setupBacktrace),
+                          shutdown: .none)
         }
     }
 
@@ -150,6 +151,11 @@ public struct ServiceLifecycle {
     /// Waits (blocking) until shutdown `Signal` is captured or `shutdown` is invoked on another thread.
     public func wait() {
         self.underlying.wait()
+    }
+
+    private func setupBacktrace() {
+        self.log("installing backtrace done")
+        Backtrace.install()
     }
 
     private func setupShutdownHook() {

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -154,7 +154,6 @@ public struct ServiceLifecycle {
     }
 
     private func setupBacktrace() {
-        self.log("installing backtrace done")
         Backtrace.install()
     }
 


### PR DESCRIPTION
**Motivation**
Refactor to use LifecycleTask to start the Backtrace according to https://github.com/swift-server/swift-service-lifecycle/issues/35

**Changes**
Deferred installation of Backtrace from init to instead use a LifecycleTask.

**Results**
Backtrace is started slightly later in the startup chain (e.g. after setting up signal handlers) - should be ok though, it will be the first installed task.