### PR TITLE
Install signal handlers as LifecycleTasks

### DIFF
--- a/.xcodesamplecode.plist
+++ b/.xcodesamplecode.plist
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<array/>
-</plist>

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -201,9 +201,11 @@ public struct ServiceLifecycle {
         self.underlying = ComponentLifecycle(label: self.configuration.label, logger: self.configuration.logger)
         // setup backtraces as soon as possible, so if we crash during setup we get a backtrace
         self.installBacktrace()
-        self.register(label: "Shutdown hooks",
-                      start: .sync(self.setupShutdownHook),
-                      shutdown: .none)
+        if self.configuration.shutdownSignal != nil {
+            self.register(label: "Shutdown hooks",
+                          start: .sync(self.setupShutdownHook),
+                          shutdown: .none)
+        }
     }
 
     /// Starts the provided `LifecycleTask` array.

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -183,7 +183,7 @@ public struct LifecycleShutdownHandler<State> {
 ///  By default, also install shutdown hooks based on `Signal` and backtraces.
 public struct ServiceLifecycle {
     private static let backtracesInstalled = AtomicBoolean(false)
-    private static let signalHandlerInstalled = AtomicBoolean(false)
+    private static let shutdownHooksInstalled = AtomicBoolean(false)
 
     private let configuration: Configuration
 
@@ -202,7 +202,7 @@ public struct ServiceLifecycle {
         self.underlying = ComponentLifecycle(label: self.configuration.label, logger: self.configuration.logger)
         // setup backtraces as soon as possible, so if we crash during setup we get a backtrace
         self.installBacktrace()
-        self.installSignalHandler()
+        self.installShutdownHooks()
     }
 
     /// Starts the provided `LifecycleTask` array.
@@ -247,15 +247,15 @@ public struct ServiceLifecycle {
         }
     }
 
-    private func installSignalHandler() {
-        if self.configuration.shutdownSignal != nil, ServiceLifecycle.signalHandlerInstalled.compareAndSwap(expected: false, desired: true) {
+    private func installShutdownHooks() {
+        if self.configuration.shutdownSignal != nil, ServiceLifecycle.shutdownHooksInstalled.compareAndSwap(expected: false, desired: true) {
             self.register(label: "Shutdown hooks",
-                          start: .sync(self.installShutdownHooks),
+                          start: .sync(self.installShutdownSignalHooks),
                           shutdown: .none)
         }
     }
 
-    private func installShutdownHooks() {
+    private func installShutdownSignalHooks() {
         self.configuration.shutdownSignal?.forEach { signal in
             let signalSource = ServiceLifecycle.trap(signal: signal, handler: { signal in
                 self.log("intercepted signal: \(signal)")

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -250,12 +250,12 @@ public struct ServiceLifecycle {
     private func installSignalHandler() {
         if self.configuration.shutdownSignal != nil, ServiceLifecycle.signalHandlerInstalled.compareAndSwap(expected: false, desired: true) {
             self.register(label: "Shutdown hooks",
-                          start: .sync(self.installShutdownHook),
+                          start: .sync(self.installShutdownHooks),
                           shutdown: .none)
         }
     }
 
-    private func installShutdownHook() {
+    private func installShutdownHooks() {
         self.configuration.shutdownSignal?.forEach { signal in
             let signalSource = ServiceLifecycle.trap(signal: signal, handler: { signal in
                 self.log("intercepted signal: \(signal)")

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -504,8 +504,8 @@ extension LifecycleTasksContainer {
     ///    - label: label of the item, useful for debugging.
     ///    - start: `Handler` to perform the startup.
     ///    - shutdown: `Handler` to perform the shutdown.
-    public func register(label: String, start: LifecycleHandler, shutdown: LifecycleHandler) {
-        self.register(_LifecycleTask(label: label, shutdownIfNotStarted: nil, start: start, shutdown: shutdown))
+    public func register(label: String, start: LifecycleHandler, shutdown: LifecycleHandler, shutdownIfNotStarted: Bool? = nil) {
+        self.register(_LifecycleTask(label: label, shutdownIfNotStarted: shutdownIfNotStarted, start: start, shutdown: shutdown))
     }
 
     /// Adds a `LifecycleTask` to a `LifecycleTasks` collection.

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -251,12 +251,12 @@ public struct ServiceLifecycle {
     private func installSignalhandler() {
         if self.configuration.shutdownSignal != nil, ServiceLifecycle.signalHandlerInstalled.compareAndSwap(expected: false, desired: true) {
             self.register(label: "Shutdown hooks",
-                          start: .sync(self.setupShutdownHook),
-                       shutdown: .sync(self.teardownShutdownHook))
+                          start: .sync(self.installShutdownHook),
+                       shutdown: .sync(self.deinstallShutdownHook))
         }
     }
 
-    private func setupShutdownHook() {
+    private func installShutdownHook() {
         self.configuration.shutdownSignal?.forEach { signal in
             ServiceLifecycle.signalHandlerSources.append(ServiceLifecycle.trap(signal: signal, handler: { signal in
                 self.log("intercepted signal: \(signal)")
@@ -265,7 +265,7 @@ public struct ServiceLifecycle {
         }
     }
 
-    private func teardownShutdownHook() {
+    private func deinstallShutdownHook() {
         for source in ServiceLifecycle.signalHandlerSources {
             source.cancel()
         }

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -269,6 +269,7 @@ public struct ServiceLifecycle {
         for source in ServiceLifecycle.signalHandlerSources {
             source.cancel()
         }
+        ServiceLifecycle.signalHandlerSources = []
     }
 
     private func log(_ message: String) {

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -252,7 +252,7 @@ public struct ServiceLifecycle {
         if self.configuration.shutdownSignal != nil, ServiceLifecycle.signalHandlerInstalled.compareAndSwap(expected: false, desired: true) {
             self.register(label: "Shutdown hooks",
                           start: .sync(self.installShutdownHook),
-                       shutdown: .sync(self.deinstallShutdownHook))
+                          shutdown: .sync(self.deinstallShutdownHook))
         }
     }
 

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -183,6 +183,8 @@ public struct LifecycleShutdownHandler<State> {
 ///  By default, also install shutdown hooks based on `Signal` and backtraces.
 public struct ServiceLifecycle {
     private static let backtracesInstalled = AtomicBoolean(false)
+    private static let signalHandlerInstalled = AtomicBoolean(false)
+    private static var signalHandlerSources = [DispatchSourceSignal]()
 
     private let configuration: Configuration
 
@@ -201,11 +203,7 @@ public struct ServiceLifecycle {
         self.underlying = ComponentLifecycle(label: self.configuration.label, logger: self.configuration.logger)
         // setup backtraces as soon as possible, so if we crash during setup we get a backtrace
         self.installBacktrace()
-        if self.configuration.shutdownSignal != nil {
-            self.register(label: "Shutdown hooks",
-                          start: .sync(self.setupShutdownHook),
-                          shutdown: .none)
-        }
+        self.installSignalhandler()
     }
 
     /// Starts the provided `LifecycleTask` array.
@@ -250,16 +248,26 @@ public struct ServiceLifecycle {
         }
     }
 
+    private func installSignalhandler() {
+        if self.configuration.shutdownSignal != nil, ServiceLifecycle.signalHandlerInstalled.compareAndSwap(expected: false, desired: true) {
+            self.register(label: "Shutdown hooks",
+                          start: .sync(self.setupShutdownHook),
+                       shutdown: .sync(self.teardownShutdownHook))
+        }
+    }
+
     private func setupShutdownHook() {
         self.configuration.shutdownSignal?.forEach { signal in
-            self.log("setting up shutdown hook on \(signal)")
-            let signalSource = ServiceLifecycle.trap(signal: signal, handler: { signal in
+            ServiceLifecycle.signalHandlerSources.append(ServiceLifecycle.trap(signal: signal, handler: { signal in
                 self.log("intercepted signal: \(signal)")
                 self.shutdown()
-            }, cancelAfterTrap: true)
-            self.underlying.shutdownGroup.notify(queue: .global()) {
-                signalSource.cancel()
-            }
+            }, cancelAfterTrap: true))
+        }
+    }
+
+    private func teardownShutdownHook() {
+        for source in ServiceLifecycle.signalHandlerSources {
+            source.cancel()
         }
     }
 

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -201,6 +201,9 @@ public struct ServiceLifecycle {
         self.underlying = ComponentLifecycle(label: self.configuration.label, logger: self.configuration.logger)
         // setup backtraces as soon as possible, so if we crash during setup we get a backtrace
         self.installBacktrace()
+        self.register(label: "Shutdown hooks",
+                      start: .sync(self.setupShutdownHook),
+                      shutdown: .none)
     }
 
     /// Starts the provided `LifecycleTask` array.
@@ -212,7 +215,6 @@ public struct ServiceLifecycle {
         guard self.underlying.idle else {
             preconditionFailure("already started")
         }
-        self.setupShutdownHook()
         self.underlying.start(on: self.configuration.callbackQueue, callback)
     }
 
@@ -222,7 +224,6 @@ public struct ServiceLifecycle {
         guard self.underlying.idle else {
             preconditionFailure("already started")
         }
-        self.setupShutdownHook()
         try self.underlying.startAndWait(on: self.configuration.callbackQueue)
     }
 


### PR DESCRIPTION
Motivation:

Small code cleanup, reusing LifecycleTask as the shutdown hooks are
to be installed just at the beginning of that chain of events anyway.
Discussed previously in context of https://github.com/swift-server/swift-service-lifecycle/pull/87

Modifications:

Moved signal handler installation to LifecycleTask instead of direct calls.

Result:

Slightly simpler code.