### PR TITLE
Import Atomics @_implementationOnly

### DIFF
--- a/Sources/Lifecycle/Atomics.swift
+++ b/Sources/Lifecycle/Atomics.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Atomics)
+#if swift(>=5.1)
+@_implementationOnly import Atomics
+#else
 import Atomics
+#endif
 #else
 import CLifecycleHelpers
 #endif


### PR DESCRIPTION
Since `swift-atomics` is not 1.0 we should ensure that we don't leak its API. For this reason we should import it as `@_implementationOnly`.