### PR TITLE
make the underlying component lifecycle private again

### DIFF
--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -190,7 +190,7 @@ public struct ServiceLifecycle {
     ///
     /// Designed for composition purposes, mainly for frameworks that need to offer both top-level start/stop functionality and composition into larger systems.
     /// In other words, should not be used outside the context of building an Application framework.
-    public let underlying: ComponentLifecycle
+    private let underlying: ComponentLifecycle
 
     /// Creates a `ServiceLifecycle` instance.
     ///

--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -187,9 +187,6 @@ public struct ServiceLifecycle {
     private let configuration: Configuration
 
     /// The underlying `ComponentLifecycle` instance
-    ///
-    /// Designed for composition purposes, mainly for frameworks that need to offer both top-level start/stop functionality and composition into larger systems.
-    /// In other words, should not be used outside the context of building an Application framework.
     private let underlying: ComponentLifecycle
 
     /// Creates a `ServiceLifecycle` instance.


### PR DESCRIPTION
motivation: there is no need to explose the underlying component lifecycle, since there are better composition solutions

changets: make ServiceLifecycle::underlying private (again)