### PR TITLE
add lifecycle metrics

### DIFF
--- a/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
@@ -66,6 +66,7 @@ extension ComponentLifecycleTests {
             ("testStatefulNIO", testStatefulNIO),
             ("testStatefulNIOStartFailure", testStatefulNIOStartFailure),
             ("testStatefulNIOShutdownFailure", testStatefulNIOShutdownFailure),
+            ("testMetrics", testMetrics),
         ]
     }
 }

--- a/Tests/LifecycleTests/ComponentLifecycleTests.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests.swift
@@ -1265,7 +1265,7 @@ final class ComponentLifecycleTests: XCTestCase {
         lifecycle.wait()
         XCTAssertEqual(metrics.counters["\(lifecycle.label).lifecycle.start"]?.value, 1, "expected start counter to be 1")
         XCTAssertEqual(metrics.counters["\(lifecycle.label).lifecycle.shutdown"]?.value, 1, "expected shutdown counter to be 1")
-        items.forEach { XCTAssertGreaterThan(metrics.timers["\(lifecycle.label).\($0.label).lifecycle.shutdown"]?.value ?? 0, 0, "expected start timer to be non-zero") }
+        items.forEach { XCTAssertGreaterThan(metrics.timers["\(lifecycle.label).\($0.label).lifecycle.start"]?.value ?? 0, 0, "expected start timer to be non-zero") }
         items.forEach { XCTAssertGreaterThan(metrics.timers["\(lifecycle.label).\($0.label).lifecycle.shutdown"]?.value ?? 0, 0, "expected shutdown timer to be non-zero") }
     }
 }


### PR DESCRIPTION
motivation: startup/shutdown metrics are important for real-life services, for example spike in start metrics indicates a crash-loop

changes:
* add start and shutdown counters to ComponentLifecycle
* add start and shutdown timers to report duration of startup and shutdown operations