### PR TITLE
add handlers that support async functions

### DIFF
--- a/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
@@ -66,6 +66,10 @@ extension ComponentLifecycleTests {
             ("testStatefulNIO", testStatefulNIO),
             ("testStatefulNIOStartFailure", testStatefulNIOStartFailure),
             ("testStatefulNIOShutdownFailure", testStatefulNIOShutdownFailure),
+            ("testAsyncAwait", testAsyncAwait),
+            ("testAsyncAwaitStateful", testAsyncAwaitStateful),
+            ("testAsyncAwaitErrorOnStart", testAsyncAwaitErrorOnStart),
+            ("testAsyncAwaitErrorOnShutdown", testAsyncAwaitErrorOnShutdown),
             ("testMetrics", testMetrics),
         ]
     }


### PR DESCRIPTION
motivation: async/await is coming in 5.5, take first steps to support it

changes:
* introduce handler initializers that takes async functions (@escaping () async throws -> Void, @escaping () async throws -> State)
* add tests