### PR TITLE
when shutdownIfNotStarted is set to false, dont shutdown items that failed to start

### DIFF
--- a/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
@@ -59,6 +59,7 @@ extension ComponentLifecycleTests {
             ("testNOOPHandlers", testNOOPHandlers),
             ("testShutdownOnlyStarted", testShutdownOnlyStarted),
             ("testShutdownWhenStartFailedIfAsked", testShutdownWhenStartFailedIfAsked),
+            ("testShutdownWhenStartFailsAndAsked", testShutdownWhenStartFailsAndAsked),
             ("testStatefulSync", testStatefulSync),
             ("testStatefulSyncStartError", testStatefulSyncStartError),
             ("testStatefulSyncShutdownError", testStatefulSyncShutdownError),
@@ -71,6 +72,7 @@ extension ComponentLifecycleTests {
             ("testAsyncAwait", testAsyncAwait),
             ("testAsyncAwaitStateful", testAsyncAwaitStateful),
             ("testAsyncAwaitErrorOnStart", testAsyncAwaitErrorOnStart),
+            ("testAsyncAwaitErrorOnStartShutdownRequested", testAsyncAwaitErrorOnStartShutdownRequested),
             ("testAsyncAwaitErrorOnShutdown", testAsyncAwaitErrorOnShutdown),
             ("testMetrics", testMetrics),
         ]


### PR DESCRIPTION
motivation: improve confusing behavior

changes:
* change startTask to return an array of started tasks instead of an index
* only shutdown successfully started tasks or ones that have explicitly set shutdownIfNotStarted to true
* add and adjust tests