### PR TITLE
only install jazzy on latest ubuntu versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,9 +18,9 @@ RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools 
 
 # ruby and jazzy for docs generation
 RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
-# switch of gem docs building
-RUN echo "gem: --no-document" > ~/.gemrc
-RUN if [ "${ubuntu_version}" != "xenial" ] ; then gem install jazzy -v 0.13.7 ; fi
+# jazzy no longer works on older version of ubuntu as ruby is too old.
+RUN if [ "${ubuntu_version}" = "focal" ] ; then echo "gem: --no-document" > ~/.gemrc ; fi
+RUN if [ "${ubuntu_version}" = "focal" ] ; then gem install jazzy ; fi
 
 # tools
 RUN mkdir -p $HOME/.tools


### PR DESCRIPTION
motivation: jazzy no longer works on older version of ubuntu as ruby is too old

changes: update docker to only install jazzy on latest ubuntu versions