### PR TITLE
shutdown any task that have shutdownIfNotStarted set to true when shutting down a never-started-lifecycle

### DIFF
--- a/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests+XCTest.swift
@@ -30,6 +30,8 @@ extension ComponentLifecycleTests {
             ("testUserDefinedCallbackQueue", testUserDefinedCallbackQueue),
             ("testShutdownWhileStarting", testShutdownWhileStarting),
             ("testShutdownWhenIdle", testShutdownWhenIdle),
+            ("testShutdownWhenIdleAndNoItems", testShutdownWhenIdleAndNoItems),
+            ("testIfNotStartedWhenIdle", testIfNotStartedWhenIdle),
             ("testShutdownWhenShutdown", testShutdownWhenShutdown),
             ("testShutdownDuringHangingStart", testShutdownDuringHangingStart),
             ("testShutdownErrors", testShutdownErrors),


### PR DESCRIPTION
motivation: more reliable shutdown in edge cases where lifecycle never gets started

changes: when shutting down an idle lifecycle, try to shutdown any tasks that have shutdownIfNotStarted set to true