### PR TITLE
Use swift-atomics from v1.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
 
 #if compiler(>=5.2)
 package.dependencies += [
-    .package(url: "https://github.com/apple/swift-atomics.git", .exact("0.0.3")), // exact since < 1.0
+    .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"), // exact since < 1.0
 ]
 package.targets += [
     .target(name: "Lifecycle", dependencies: ["Logging", "Metrics", "Backtrace", "Atomics"]),


### PR DESCRIPTION
Now swift-atomics has hit v1.0.0 we should use it