### PR TITLE
Adds Swift Concurrency Availability to macOS 10.15, iOS 13, tvOS 13, and watchOS 6

### DIFF
--- a/Sources/Lifecycle/Lifecycle.swift
+++ b/Sources/Lifecycle/Lifecycle.swift
@@ -95,8 +95,8 @@ public struct LifecycleHandler {
     }
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-@available(macOS 12.0, *)
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension LifecycleHandler {
     public init(_ handler: @escaping () async throws -> Void) {
         self = LifecycleHandler { callback in
@@ -159,8 +159,8 @@ public struct LifecycleStartHandler<State> {
     }
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-@available(macOS 12.0, *)
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension LifecycleStartHandler {
     public init(_ handler: @escaping () async throws -> State) {
         self = LifecycleStartHandler { callback in
@@ -221,8 +221,8 @@ public struct LifecycleShutdownHandler<State> {
     }
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-@available(macOS 12.0, *)
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension LifecycleShutdownHandler {
     public init(_ handler: @escaping (State) async throws -> Void) {
         self = LifecycleShutdownHandler { state, callback in


### PR DESCRIPTION
Adds Swift Concurrency Availability to macOS 10.15, iOS 13, tvOS 13, and watchOS 6.

_(Shamelessly copying from https://github.com/apple/swift-nio/pull/2004 @PSchmiedmayer)_

### Motivation:

With the support for Swift Concurrency coming to macOS 10.15, iOS 13, tvOS 13, and watchOS 6 with Xcode 13.2, the Swift Concurrency features should be available when compiling for these targets using Xcode 13.2.

### Modifications:

Change the `@available` annotations to macOS 10.15, iOS 13, tvOS 13, and watchOS 6.

### Result:

The Swift Concurrency features are marked with `@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)` and can therefore be used on macOS 10.15, iOS 13, tvOS 13, and watchOS 6.