### PR TITLE
shutdown() should cancel the signal handlers installed by start()

### DIFF
--- a/Sources/Lifecycle/Locks.swift
+++ b/Sources/Lifecycle/Locks.swift
@@ -81,7 +81,7 @@ extension Lock {
     /// - Parameter body: The block to execute while holding the lock.
     /// - Returns: The value returned by the block.
     @inlinable
-    internal func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
         self.lock()
         defer {
             self.unlock()
@@ -91,7 +91,7 @@ extension Lock {
 
     // specialise Void return (for performance)
     @inlinable
-    internal func withLockVoid(_ body: () throws -> Void) rethrows {
+    func withLockVoid(_ body: () throws -> Void) rethrows {
         try self.withLock(body)
     }
 }

--- a/Tests/LifecycleTests/ComponentLifecycleTests.swift
+++ b/Tests/LifecycleTests/ComponentLifecycleTests.swift
@@ -53,7 +53,7 @@ final class ComponentLifecycleTests: XCTestCase {
                                       dispatchPrecondition(condition: .onQueue(.global()))
                                       XCTAssertTrue(startCalls.contains(id))
                                       stopCalls.append(id)
-                                 })
+                                  })
         }
         lifecycle.register(items)
 
@@ -92,7 +92,7 @@ final class ComponentLifecycleTests: XCTestCase {
                                       dispatchPrecondition(condition: .onQueue(testQueue))
                                       XCTAssertTrue(startCalls.contains(id))
                                       stopCalls.append(id)
-                                 })
+                                  })
         }
         lifecycle.register(items)
 

--- a/Tests/LifecycleTests/ServiceLifecycleTests+XCTest.swift
+++ b/Tests/LifecycleTests/ServiceLifecycleTests+XCTest.swift
@@ -35,6 +35,7 @@ extension ServiceLifecycleTests {
             ("testSignalDescription", testSignalDescription),
             ("testBacktracesInstalledOnce", testBacktracesInstalledOnce),
             ("testRepeatShutdown", testRepeatShutdown),
+            ("testShutdownCancelSignal", testShutdownCancelSignal),
         ]
     }
 }

--- a/Tests/LifecycleTests/ServiceLifecycleTests.swift
+++ b/Tests/LifecycleTests/ServiceLifecycleTests.swift
@@ -274,7 +274,7 @@ final class ServiceLifecycleTests: XCTestCase {
 
     func testShutdownCancelSignal() {
         if ProcessInfo.processInfo.environment["SKIP_SIGNAL_TEST"].flatMap(Bool.init) ?? false {
-            print("skipping testRepeatShutdown")
+            print("skipping testShutdownCancelSignal")
             return
         }
 

--- a/Tests/LifecycleTests/ServiceLifecycleTests.swift
+++ b/Tests/LifecycleTests/ServiceLifecycleTests.swift
@@ -271,4 +271,47 @@ final class ServiceLifecycleTests: XCTestCase {
 
         XCTAssertEqual(attempts, count)
     }
+
+    func testShutdownCancelSignal() {
+        if ProcessInfo.processInfo.environment["SKIP_SIGNAL_TEST"].flatMap(Bool.init) ?? false {
+            print("skipping testRepeatShutdown")
+            return
+        }
+
+        struct Service {
+            static let signal = ServiceLifecycle.Signal.ALRM
+
+            let lifecycle: ServiceLifecycle
+
+            init() {
+                self.lifecycle = ServiceLifecycle(configuration: .init(shutdownSignal: [Service.signal]))
+                self.lifecycle.register(GoodItem())
+            }
+        }
+
+        let service = Service()
+        service.lifecycle.start { error in
+            XCTAssertNil(error, "not expecting error")
+            kill(getpid(), Service.signal.rawValue)
+        }
+        service.lifecycle.wait()
+
+        var count = 0
+        let sync = DispatchGroup()
+        sync.enter()
+        let signalSource = ServiceLifecycle.trap(signal: Service.signal, handler: { _ in
+            count = count + 1 // not thread safe but fine for this purpose
+            sync.leave()
+        }, cancelAfterTrap: false)
+
+        // since we are removing the hook added by lifecycle on shutdown,
+        // this will fail unless a new hook is set up as done above
+        kill(getpid(), Service.signal.rawValue)
+
+        XCTAssertEqual(.success, sync.wait(timeout: .now() + 2))
+        XCTAssertEqual(count, 1)
+
+        signalSource.cancel()
+        ServiceLifecycle.removeTrap(signal: Service.signal)
+    }
 }


### PR DESCRIPTION
motivation: allow easier testing of shutdown hooks

changes:
* introduce ServiceLifecycle.removeTrap which removes a trap
* call ServiceLifecycle.removeTrap when setting up the shutdown hook
* make the shutdown hook cleanup into a lifecycle task to ensure correct ordering
* add tests
* improve logging

rdar://89552798