### PR TITLE
Fixes cancelOnGracefulShutdown issue (#135)

### DIFF
--- a/Sources/ServiceLifecycle/GracefulShutdown.swift
+++ b/Sources/ServiceLifecycle/GracefulShutdown.swift
@@ -80,12 +80,12 @@ public func cancelOnGracefulShutdown<T>(_ operation: @Sendable @escaping () asyn
         }
 
         let result = try await group.next()
+        group.cancelAll() // currently needed, as the group does not always auto-cancel tasks on return
 
         switch result {
         case .value(let t):
             return t
         case .gracefulShutdown:
-            group.cancelAll()
             switch try await group.next() {
             case .value(let t):
                 return t

--- a/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift
+++ b/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift
@@ -233,6 +233,17 @@ final class GracefulShutdownTests: XCTestCase {
         }
     }
 
+    func testResumesCancelOnGracefulShutdownWithResult() async throws {
+        await testGracefulShutdown { _ in
+            let result = await cancelOnGracefulShutdown {
+                await Task.yield()
+                return "hello"
+            }
+
+            XCTAssertEqual(result, "hello")
+        }
+    }
+
     func testIsShuttingDownGracefully() async throws {
         await testGracefulShutdown { gracefulShutdownTestTrigger in
             XCTAssertFalse(Task.isShuttingDownGracefully)


### PR DESCRIPTION
Motivation:
+ cancelOnGracefulShutdown was getting stuck on macOS

Modifications:
+ added explicit group.cancelAll() to all execution paths