### PR TITLE
Rename `shutdownGracefully` to `triggerGracefulShutdown` on the `ServiceGroup`

### DIFF
--- a/Sources/ServiceLifecycle/ServiceGroup.swift
+++ b/Sources/ServiceLifecycle/ServiceGroup.swift
@@ -102,7 +102,7 @@ public actor ServiceGroup: Sendable {
     /// Triggers the graceful shutdown of all services.
     ///
     /// This method returns immediately after triggering the graceful shutdown and doesn't wait until the service have shutdown.
-    public func shutdownGracefully() async {
+    public func triggerGracefulShutdown() async {
         switch self.state {
         case .initial:
             // We aren't even running so we can stop right away.

--- a/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
+++ b/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
@@ -487,7 +487,7 @@ final class ServiceGroupTests: XCTestCase {
         }
     }
 
-    func testShutdownGracefully() async throws {
+    func testTriggerGracefulShutdown() async throws {
         let configuration = ServiceGroupConfiguration(gracefulShutdownSignals: [])
         let service1 = MockService(description: "Service1")
         let service2 = MockService(description: "Service2")
@@ -508,7 +508,7 @@ final class ServiceGroupTests: XCTestCase {
             var eventIterator3 = service3.events.makeAsyncIterator()
             await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
 
-            await serviceGroup.shutdownGracefully()
+            await serviceGroup.triggerGracefulShutdown()
 
             // The last service should receive the shutdown signal first
             await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)


### PR DESCRIPTION
# Motivation
The current naming of `shutdownGracefully()` on the `ServiceGroup` caused some confusion since callers had to `await` the call due the `ServiceGroup` being an `actor`. This lead users to believe that the method waited until the graceful shutdown was completed; however, the method only triggered the shutdown and exited.

# Modification
This PR renames `ServiceGroup/shutdownGracefully()` to `ServiceGroup/triggerGracefulShtudown()`.

# Result
Less confusion around the behaviour of triggering a graceful shutdown on the `ServiceGroup`.