### PR TITLE
Add support for `SIGQUIT`

### DIFF
--- a/Sources/UnixSignals/UnixSignal.swift
+++ b/Sources/UnixSignals/UnixSignal.swift
@@ -30,6 +30,7 @@ public struct UnixSignal: Hashable, Sendable, CustomStringConvertible {
         case sigusr1
         case sigusr2
         case sigalrm
+        case sigquit
     }
 
     private let wrapped: Wrapped
@@ -49,6 +50,8 @@ public struct UnixSignal: Hashable, Sendable, CustomStringConvertible {
     public static let sighup = Self(.sighup)
     /// Issued if the user sends an interrupt signal.
     public static let sigint = Self(.sigint)
+    /// Issued if the user sends a quit signal.
+    public static let sigquit = Self(.sigquit)
     /// Software termination signal.
     public static let sigterm = Self(.sigterm)
     public static let sigusr1 = Self(.sigusr1)
@@ -66,6 +69,8 @@ extension UnixSignal.Wrapped: CustomStringConvertible {
             return "SIGHUP"
         case .sigint:
             return "SIGINT"
+        case .sigquit:
+            return "SIGQUIT"
         case .sigterm:
             return "SIGTERM"
         case .sigusr1:
@@ -85,6 +90,8 @@ extension UnixSignal.Wrapped {
             return SIGHUP
         case .sigint:
             return SIGINT
+        case .sigquit:
+            return SIGQUIT
         case .sigterm:
             return SIGTERM
         case .sigusr1:

--- a/Tests/UnixSignalsTests/UnixSignalTests.swift
+++ b/Tests/UnixSignalsTests/UnixSignalTests.swift
@@ -114,6 +114,7 @@ final class UnixSignalTests: XCTestCase {
 
         assert(.sigalrm, rawValue: SIGALRM)
         assert(.sigint, rawValue: SIGINT)
+        assert(.sigquit, rawValue: SIGQUIT)
         assert(.sighup, rawValue: SIGHUP)
         assert(.sigusr1, rawValue: SIGUSR1)
         assert(.sigusr2, rawValue: SIGUSR2)
@@ -127,6 +128,7 @@ final class UnixSignalTests: XCTestCase {
 
         assert(.sigalrm, description: "SIGALRM")
         assert(.sigint, description: "SIGINT")
+        assert(.sigquit, description: "SIGQUIT")
         assert(.sighup, description: "SIGHUP")
         assert(.sigusr1, description: "SIGUSR1")
         assert(.sigusr2, description: "SIGUSR2")


### PR DESCRIPTION
# Motivation
Some applications want to react to `SIGQUIT` which is similar to `SIGINT` but normally maps to a different key `C-\`.

# Modification
This PR adds support for `SIGQUIT` in the `UnixSignal`s module.

# Result
Support for `SIGQUIT`.