### PR TITLE
Provide a `ServiceGroupConfiguration` initializer without `gracefulSh…

### DIFF
--- a/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift
+++ b/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift
@@ -54,4 +54,9 @@ public struct ServiceGroupConfiguration: Hashable, Sendable {
         self.gracefulShutdownSignals = gracefulShutdownSignals
         self.logging = .init()
     }
+
+    /// Initializes a new ``ServiceGroupConfiguration``.
+    public init() {
+        self.init(gracefulShutdownSignals: [])
+    }
 }


### PR DESCRIPTION
…utdownSignals` signals

# Motivation
When using the `ServiceGroup` in non-top-level setups such as inside a `Service.run()` method then it is confusing if you are forced to pass `gracefulShutdownSignals`.

# Modification
This PR adds a new initializer to `ServiceGroupConfiguration` which takes no arguments.

# Result
Less confusion when using the service group inside a non-top-level context.