### PR TITLE
Add convenience init to the group

### DIFF
--- a/Sources/ServiceLifecycle/ServiceGroup.swift
+++ b/Sources/ServiceLifecycle/ServiceGroup.swift
@@ -59,6 +59,29 @@ public actor ServiceGroup: Sendable {
         self.loggingConfiguration = configuration.logging
     }
 
+    /// Initializes a new ``ServiceGroup``.
+    ///
+    /// - Parameters:
+    ///   - services: The groups's service configurations.
+    ///   - gracefulShutdownSignals: The signals that lead to graceful shutdown.
+    ///   - cancellationSignals: The signals that lead to cancellation.
+    ///   - logger: The group's logger.
+    public init(
+        services: [any Service],
+        gracefulShutdownSignals: [UnixSignal] = [],
+        cancellationSignals: [UnixSignal] = [],
+        logger: Logger
+    ) {
+        let configuration = ServiceGroupConfiguration(
+            services: services.map { ServiceGroupConfiguration.ServiceConfiguration(service: $0) },
+            gracefulShutdownSignals: gracefulShutdownSignals,
+            cancellationSignals: cancellationSignals,
+            logger: logger
+        )
+
+        self.init(configuration: configuration)
+    }
+
     @available(*, deprecated)
     public init(
         services: [any Service],


### PR DESCRIPTION
# Motivation
Right now creating a `ServiceGroup` always requires creating a `ServiceGroupConfiguration`. This is making the barrier to use the group higher than needed for the 99% use-case.

# Modification
This PR adds a new init on the `ServiceGroup` that takes an array of services, graceful shutdown & cancellation signals and the logger.

# Result
Easier use of the service group for the 99% use-case.