### PR TITLE
Add async gracefulShutdown function to wait on graceful shutdown trigger

### DIFF
--- a/Sources/ServiceLifecycle/CancellationWaiter.swift
+++ b/Sources/ServiceLifecycle/CancellationWaiter.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftServiceLifecycle open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftServiceLifecycle project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// An actor that provides a function to wait on cancellation/graceful shutdown.
+@usableFromInline
+actor CancellationWaiter {
+    private var taskContinuation: CheckedContinuation<Void, Error>?
+
+    @usableFromInline
+    init() {}
+
+    @usableFromInline
+    func wait() async throws {
+        try await withTaskCancellationHandler {
+            try await withGracefulShutdownHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    self.taskContinuation = continuation
+                }
+            } onGracefulShutdown: {
+                Task {
+                    await self.finish()
+                }
+            }
+        } onCancel: {
+            Task {
+                await self.finish(throwing: CancellationError())
+            }
+        }
+    }
+
+    private func finish(throwing error: Error? = nil) {
+        if let error {
+            self.taskContinuation?.resume(throwing: error)
+        } else {
+            self.taskContinuation?.resume()
+        }
+        self.taskContinuation = nil
+    }
+}


### PR DESCRIPTION
# Motivation
Sometimes, it's useful to wait for graceful shutdown to happen before resuming execution on a task.

This can be of particular interest when we don't have anything to do in a Service's `run` method but want to make sure some cleanup happens on graceful shutdown.
In this scenario, we can achieve this by calling `await gracefulShutdown()` in `run()`, followed by whatever cleanup we must do.

# Modification
This PR adds a new `gracefulShutdown()` function to the `GracefulShutdown` suite. 

# Result
A new `gracefulShutdown()` method in the `GracefulShutdown` suite. 