### PR TITLE
Add support for `SIGWINCH`

### DIFF
--- a/Sources/UnixSignals/UnixSignal.swift
+++ b/Sources/UnixSignals/UnixSignal.swift
@@ -31,6 +31,7 @@ public struct UnixSignal: Hashable, Sendable, CustomStringConvertible {
         case sigusr2
         case sigalrm
         case sigquit
+        case sigwinch
     }
 
     private let wrapped: Wrapped
@@ -57,6 +58,8 @@ public struct UnixSignal: Hashable, Sendable, CustomStringConvertible {
     public static let sigusr1 = Self(.sigusr1)
     public static let sigusr2 = Self(.sigusr2)
     public static let sigalrm = Self(.sigalrm)
+    /// Signal when the window is resized.
+    public static let sigwinch = Self(.sigwinch)
 }
 
 extension UnixSignal.Wrapped: Hashable {}
@@ -79,6 +82,8 @@ extension UnixSignal.Wrapped: CustomStringConvertible {
             return "SIGUSR2"
         case .sigalrm:
             return "SIGALRM"
+        case .sigwinch:
+            return "SIGWINCH"
         }
     }
 }
@@ -100,6 +105,8 @@ extension UnixSignal.Wrapped {
             return SIGUSR2
         case .sigalrm:
             return SIGALRM
+        case .sigwinch:
+            return SIGWINCH
         }
     }
 }

--- a/Tests/UnixSignalsTests/UnixSignalTests.swift
+++ b/Tests/UnixSignalsTests/UnixSignalTests.swift
@@ -133,6 +133,7 @@ final class UnixSignalTests: XCTestCase {
         assert(.sigusr1, description: "SIGUSR1")
         assert(.sigusr2, description: "SIGUSR2")
         assert(.sigterm, description: "SIGTERM")
+        assert(.sigwinch, description: "SIGWINCH")
     }
 
     func testCancelledTask() async throws {


### PR DESCRIPTION
# Motivation
`SIGWINCH` is sent to applications when the window resizes. This is useful to observe for terminal applications to reformat the logging one resize.

# Modification
This PR adds support for `SIGWINCH` in `UnixSignal`s.