### PR TITLE
Add a configurable escalation behaviour

### DIFF
--- a/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift
+++ b/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift
@@ -96,6 +96,65 @@ public struct ServiceGroupConfiguration: Sendable {
         }
     }
 
+    /// The group's escalation configuration.
+    public struct EscalationBehaviour: Sendable {
+        /// The maximum amount of time that graceful shutdown is allowed to take.
+        ///
+        /// After this time has elapsed graceful shutdown will be escalated to task cancellation.
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+        public var maximumGracefulShutdownDuration: Duration? {
+            get {
+                if let maximumGracefulShutdownDuration = self._maximumGracefulShutdownDuration {
+                    return .init(
+                        secondsComponent: maximumGracefulShutdownDuration.secondsComponent,
+                        attosecondsComponent: maximumGracefulShutdownDuration.attosecondsComponent
+                    )
+                } else {
+                    return nil
+                }
+            }
+            set {
+                if let newValue = newValue {
+                    self._maximumGracefulShutdownDuration = (newValue.components.seconds, newValue.components.attoseconds)
+                } else {
+                    self._maximumCancellationDuration = nil
+                }
+            }
+        }
+
+        /// The maximum amount of time that task cancellation is allowed to take.
+        ///
+        /// After this time has elapsed task cancellation will be escalated to a `fatalError`.
+        ///
+        /// - Important: This setting is useful to guarantee that your application will exit at some point and
+        /// should be used to identify APIs that are not properly implementing task cancellation.
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+        public var maximumCancellationDuration: Duration? {
+            get {
+                if let maximumCancellationDuration = self._maximumCancellationDuration {
+                    return .init(
+                        secondsComponent: maximumCancellationDuration.secondsComponent,
+                        attosecondsComponent: maximumCancellationDuration.attosecondsComponent
+                    )
+                } else {
+                    return nil
+                }
+            }
+            set {
+                if let newValue = newValue {
+                    self._maximumCancellationDuration = (newValue.components.seconds, newValue.components.attoseconds)
+                } else {
+                    self._maximumCancellationDuration = nil
+                }
+            }
+        }
+
+        private var _maximumGracefulShutdownDuration: (secondsComponent: Int64, attosecondsComponent: Int64)?
+        private var _maximumCancellationDuration: (secondsComponent: Int64, attosecondsComponent: Int64)?
+
+        public init() {}
+    }
+
     /// The groups's service configurations.
     public var services: [ServiceConfiguration]
 
@@ -110,6 +169,9 @@ public struct ServiceGroupConfiguration: Sendable {
 
     /// The group's logging configuration.
     public var logging = LoggingConfiguration()
+
+    /// The group's escalation configuration.
+    public var escalation = EscalationBehaviour()
 
     /// Initializes a new ``ServiceGroupConfiguration``.
     ///

--- a/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift
+++ b/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift
@@ -96,65 +96,6 @@ public struct ServiceGroupConfiguration: Sendable {
         }
     }
 
-    /// The group's escalation configuration.
-    public struct EscalationBehaviour: Sendable {
-        /// The maximum amount of time that graceful shutdown is allowed to take.
-        ///
-        /// After this time has elapsed graceful shutdown will be escalated to task cancellation.
-        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        public var maximumGracefulShutdownDuration: Duration? {
-            get {
-                if let maximumGracefulShutdownDuration = self._maximumGracefulShutdownDuration {
-                    return .init(
-                        secondsComponent: maximumGracefulShutdownDuration.secondsComponent,
-                        attosecondsComponent: maximumGracefulShutdownDuration.attosecondsComponent
-                    )
-                } else {
-                    return nil
-                }
-            }
-            set {
-                if let newValue = newValue {
-                    self._maximumGracefulShutdownDuration = (newValue.components.seconds, newValue.components.attoseconds)
-                } else {
-                    self._maximumCancellationDuration = nil
-                }
-            }
-        }
-
-        /// The maximum amount of time that task cancellation is allowed to take.
-        ///
-        /// After this time has elapsed task cancellation will be escalated to a `fatalError`.
-        ///
-        /// - Important: This setting is useful to guarantee that your application will exit at some point and
-        /// should be used to identify APIs that are not properly implementing task cancellation.
-        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        public var maximumCancellationDuration: Duration? {
-            get {
-                if let maximumCancellationDuration = self._maximumCancellationDuration {
-                    return .init(
-                        secondsComponent: maximumCancellationDuration.secondsComponent,
-                        attosecondsComponent: maximumCancellationDuration.attosecondsComponent
-                    )
-                } else {
-                    return nil
-                }
-            }
-            set {
-                if let newValue = newValue {
-                    self._maximumCancellationDuration = (newValue.components.seconds, newValue.components.attoseconds)
-                } else {
-                    self._maximumCancellationDuration = nil
-                }
-            }
-        }
-
-        private var _maximumGracefulShutdownDuration: (secondsComponent: Int64, attosecondsComponent: Int64)?
-        private var _maximumCancellationDuration: (secondsComponent: Int64, attosecondsComponent: Int64)?
-
-        public init() {}
-    }
-
     /// The groups's service configurations.
     public var services: [ServiceConfiguration]
 
@@ -170,8 +111,60 @@ public struct ServiceGroupConfiguration: Sendable {
     /// The group's logging configuration.
     public var logging = LoggingConfiguration()
 
-    /// The group's escalation configuration.
-    public var escalation = EscalationBehaviour()
+    /// The maximum amount of time that graceful shutdown is allowed to take.
+    ///
+    /// After this time has elapsed graceful shutdown will be escalated to task cancellation.
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+    public var maximumGracefulShutdownDuration: Duration? {
+        get {
+            if let maximumGracefulShutdownDuration = self._maximumGracefulShutdownDuration {
+                return .init(
+                    secondsComponent: maximumGracefulShutdownDuration.secondsComponent,
+                    attosecondsComponent: maximumGracefulShutdownDuration.attosecondsComponent
+                )
+            } else {
+                return nil
+            }
+        }
+        set {
+            if let newValue = newValue {
+                self._maximumGracefulShutdownDuration = (newValue.components.seconds, newValue.components.attoseconds)
+            } else {
+                self._maximumGracefulShutdownDuration = nil
+            }
+        }
+    }
+
+    internal var _maximumGracefulShutdownDuration: (secondsComponent: Int64, attosecondsComponent: Int64)?
+
+    /// The maximum amount of time that task cancellation is allowed to take.
+    ///
+    /// After this time has elapsed task cancellation will be escalated to a `fatalError`.
+    ///
+    /// - Important: This setting is useful to guarantee that your application will exit at some point and
+    /// should be used to identify APIs that are not properly implementing task cancellation.
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+    public var maximumCancellationDuration: Duration? {
+        get {
+            if let maximumCancellationDuration = self._maximumCancellationDuration {
+                return .init(
+                    secondsComponent: maximumCancellationDuration.secondsComponent,
+                    attosecondsComponent: maximumCancellationDuration.attosecondsComponent
+                )
+            } else {
+                return nil
+            }
+        }
+        set {
+            if let newValue = newValue {
+                self._maximumCancellationDuration = (newValue.components.seconds, newValue.components.attoseconds)
+            } else {
+                self._maximumCancellationDuration = nil
+            }
+        }
+    }
+
+    internal var _maximumCancellationDuration: (secondsComponent: Int64, attosecondsComponent: Int64)?
 
     /// Initializes a new ``ServiceGroupConfiguration``.
     ///

--- a/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
+++ b/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
@@ -1190,8 +1190,8 @@ final class ServiceGroupTests: XCTestCase {
             cancellationSignals: cancellationSignals,
             logger: logger
         )
-        configuration.escalation.maximumGracefulShutdownDuration = maximumGracefulShutdownDuration
-        configuration.escalation.maximumCancellationDuration = maximumCancellationDuration
+        configuration.maximumGracefulShutdownDuration = maximumGracefulShutdownDuration
+        configuration.maximumCancellationDuration = maximumCancellationDuration
         return .init(
             configuration: configuration
         )

--- a/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
+++ b/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
@@ -588,7 +588,7 @@ final class ServiceGroupTests: XCTestCase {
         let service3 = MockService(description: "Service3")
         let serviceGroup = self.makeServiceGroup(
             services: [.init(service: service1), .init(service: service2), .init(service: service3)],
-            gracefulShutdownSignals: [.sighup],
+            gracefulShutdownSignals: [.sigwinch],
             cancellationSignals: [.sigalrm]
         )
 
@@ -607,7 +607,7 @@ final class ServiceGroupTests: XCTestCase {
             await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
 
             let pid = getpid()
-            kill(pid, UnixSignal.sighup.rawValue)
+            kill(pid, UnixSignal.sigwinch.rawValue)
 
             await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
 

--- a/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
+++ b/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
@@ -86,6 +86,7 @@ private actor MockService: Service, CustomStringConvertible {
     }
 }
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class ServiceGroupTests: XCTestCase {
     func testRun_whenAlreadyRunning() async throws {
         let mockService = MockService(description: "Service1")
@@ -1080,23 +1081,119 @@ final class ServiceGroupTests: XCTestCase {
         }
     }
 
+    func testGracefulShutdownEscalation() async throws {
+        let mockService = MockService(description: "Service1")
+        let serviceGroup = self.makeServiceGroup(
+            services: [.init(service: mockService)],
+            gracefulShutdownSignals: [.sigalrm],
+            maximumGracefulShutdownDuration: .seconds(0.1),
+            maximumCancellationDuration: .seconds(0.5)
+        )
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            var eventIterator = mockService.events.makeAsyncIterator()
+            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+
+            await serviceGroup.triggerGracefulShutdown()
+
+            await XCTAsyncAssertEqual(await eventIterator.next(), .shutdownGracefully)
+
+            await XCTAsyncAssertEqual(await eventIterator.next(), .runCancelled)
+
+            try await Task.sleep(for: .seconds(0.2))
+
+            await mockService.resumeRunContinuation(with: .success(()))
+
+            try await XCTAsyncAssertNoThrow(await group.next())
+        }
+    }
+
+    func testGracefulShutdownEscalation_whenNoCancellationEscalation() async throws {
+        let mockService = MockService(description: "Service1")
+        let serviceGroup = self.makeServiceGroup(
+            services: [.init(service: mockService)],
+            gracefulShutdownSignals: [.sigalrm],
+            maximumGracefulShutdownDuration: .seconds(0.1),
+            maximumCancellationDuration: nil
+        )
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            var eventIterator = mockService.events.makeAsyncIterator()
+            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+
+            await serviceGroup.triggerGracefulShutdown()
+
+            await XCTAsyncAssertEqual(await eventIterator.next(), .shutdownGracefully)
+
+            await XCTAsyncAssertEqual(await eventIterator.next(), .runCancelled)
+
+            try await Task.sleep(for: .seconds(0.2))
+
+            await mockService.resumeRunContinuation(with: .success(()))
+
+            try await XCTAsyncAssertNoThrow(await group.next())
+        }
+    }
+
+    func testCancellationEscalation() async throws {
+        let mockService = MockService(description: "Service1")
+        let serviceGroup = self.makeServiceGroup(
+            services: [.init(service: mockService)],
+            gracefulShutdownSignals: [.sigalrm],
+            maximumGracefulShutdownDuration: nil,
+            maximumCancellationDuration: .seconds(1)
+        )
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            var eventIterator = mockService.events.makeAsyncIterator()
+            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+
+            group.cancelAll()
+
+            await XCTAsyncAssertEqual(await eventIterator.next(), .runCancelled)
+
+            try await Task.sleep(for: .seconds(0.1))
+
+            await mockService.resumeRunContinuation(with: .success(()))
+
+            try await XCTAsyncAssertNoThrow(await group.next())
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeServiceGroup(
         services: [ServiceGroupConfiguration.ServiceConfiguration] = [],
         gracefulShutdownSignals: [UnixSignal] = .init(),
-        cancellationSignals: [UnixSignal] = .init()
+        cancellationSignals: [UnixSignal] = .init(),
+        maximumGracefulShutdownDuration: Duration? = nil,
+        maximumCancellationDuration: Duration? = .seconds(5)
     ) -> ServiceGroup {
         var logger = Logger(label: "Tests")
         logger.logLevel = .debug
 
+        var configuration = ServiceGroupConfiguration(
+            services: services,
+            gracefulShutdownSignals: gracefulShutdownSignals,
+            cancellationSignals: cancellationSignals,
+            logger: logger
+        )
+        configuration.escalation.maximumGracefulShutdownDuration = maximumGracefulShutdownDuration
+        configuration.escalation.maximumCancellationDuration = maximumCancellationDuration
         return .init(
-            configuration: .init(
-                services: services,
-                gracefulShutdownSignals: gracefulShutdownSignals,
-                cancellationSignals: cancellationSignals,
-                logger: logger
-            )
+            configuration: configuration
         )
     }
 }


### PR DESCRIPTION
# Motivation
The service group is often running multiple services and orchestrates shutdown for them. We have seen that sometimes some services never shutdown nor do they respond to task cancellation properly. This can become quite problematic when the whole application is waiting for a service to cancel and otherwise appears to be healthy but in reality can't serve any traffic.

# Modification
This PR adds a new configuration to escalate both graceful shutdown and cancellation. The escalation order is graceful shutdown -> task cancellation -> `fatalError`. The `fatalError` acts a last resort to make sure applications are never stuck.