### PR TITLE
Update `TerminationBehavior` doc comments and notes

### DIFF
--- a/Sources/ServiceLifecycle/Docs.docc/How to adopt ServiceLifecycle in applications.md
+++ b/Sources/ServiceLifecycle/Docs.docc/How to adopt ServiceLifecycle in applications.md
@@ -236,8 +236,8 @@ By default the ``ServiceGroup`` is cancelling the whole group if the one service
 returns or throws. However, in some scenarios this is totally expected e.g. when
 the ``ServiceGroup`` is used in a CLI tool to orchestrate some services while a
 command is handled. To customize the behavior you set the
-``ServiceGroupConfiguration/ServiceConfiguration/returnBehaviour`` and
-``ServiceGroupConfiguration/ServiceConfiguration/throwBehaviour``. Both of them
+``ServiceGroupConfiguration/ServiceConfiguration/successTerminationBehavior`` and
+``ServiceGroupConfiguration/ServiceConfiguration/failureTerminationBehavior``. Both of them
 offer three different options. The default behavior for both is
 ``ServiceGroupConfiguration/ServiceConfiguration/TerminationBehavior/cancelGroup``.
 You can also choose to either ignore if a service returns/throws by setting it
@@ -261,7 +261,11 @@ struct Application {
       configuration: .init(
         services: [
           .init(service: telemetryService),
-          .init(service: httpServer, returnBehavior: .shutdownGracefully, throwBehavior: .shutdownGracefully)
+          .init(
+            service: httpServer, 
+            successTerminationBehavior: .shutdownGracefully,
+            failureTerminationBehavior: .shutdownGracefully
+          )
         ],
         logger: logger
       ),

--- a/Sources/ServiceLifecycle/Docs.docc/How to adopt ServiceLifecycle in libraries.md
+++ b/Sources/ServiceLifecycle/Docs.docc/How to adopt ServiceLifecycle in libraries.md
@@ -91,8 +91,8 @@ public actor TCPEchoClient: Service {
 Since the `run()` method contains long running work, returning from it is seen
 as a failure and will lead to the ``ServiceGroup`` cancelling all other services
 by cancelling the task that is running their respective `run()` method, unless
-specified otherwise via ``ServiceGroupConfiguration.ServiceConfiguration.TerminationBehavior``
-arguments of ``ServiceGroupConfiguration.ServiceConfiguration.init``.
+specified otherwise in ``ServiceGroupConfiguration/ServiceConfiguration/successTerminationBehavior``
+and ``ServiceGroupConfiguration/ServiceConfiguration/failureTerminationBehavior``.
 
 ### Cancellation
 

--- a/Sources/ServiceLifecycle/Service.swift
+++ b/Sources/ServiceLifecycle/Service.swift
@@ -20,7 +20,9 @@ public protocol Service: Sendable {
     /// - Handling incoming connections and requests
     /// - Background refreshes
     ///
-    /// - Important: Returning or throwing from this method is indicating a failure of the service and will cause the ``ServiceGroup``
-    /// to cancel the child tasks of all other running services.
+    /// - Important: Returning or throwing from this method indicates the service should stop and will cause the
+    /// ``ServiceGroup`` to follow behaviors for the child tasks of all other running services specified in
+    /// ``ServiceGroupConfiguration/ServiceConfiguration/successTerminationBehavior`` and
+    /// ``ServiceGroupConfiguration/ServiceConfiguration/failureTerminationBehavior``.
     func run() async throws
 }

--- a/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift
+++ b/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift
@@ -47,6 +47,7 @@ public struct ServiceGroupConfiguration: Sendable {
     }
 
     public struct ServiceConfiguration: Sendable {
+        /// The behavior to follow when the service finishes its ``Service/run()`` method via returning or throwing.
         public struct TerminationBehavior: Sendable, CustomStringConvertible {
             internal enum _TerminationBehavior {
                 case cancelGroup
@@ -72,19 +73,19 @@ public struct ServiceGroupConfiguration: Sendable {
             }
         }
 
-        /// The service.
+        /// The service to which the initialized configuration applies.
         public var service: any Service
-        /// The behavior when the service returns from its `run()` method.
+        /// The behavior when the service returns from its ``Service/run()`` method.
         public var successTerminationBehavior: TerminationBehavior
-        /// The behavior when the service throws from its `run()` method.
+        /// The behavior when the service throws from its ``Service/run()`` method.
         public var failureTerminationBehavior: TerminationBehavior
 
         /// Initializes a new ``ServiceGroupConfiguration/ServiceConfiguration``.
         ///
         /// - Parameters:
-        ///   - service: The service.
-        ///   - successTerminationBehavior: The behavior when the service returns from its `run()` method.
-        ///   - failureTerminationBehavior: The behavior when the service throws from its `run()` method.
+        ///   - service: The service to which the initialized configuration applies.
+        ///   - successTerminationBehavior: The behavior when the service returns from its ``Service/run()`` method.
+        ///   - failureTerminationBehavior: The behavior when the service throws from its ``Service/run()`` method.
         public init(
             service: any Service,
             successTerminationBehavior: TerminationBehavior = .cancelGroup,


### PR DESCRIPTION
`ServiceGroupConfiguration.ServiceConfiguration.TerminationBehavior` did not seem to be mentioned in some areas of the docs, and specifically library adoption docs gave the impression that cancellation on returning from `run` is the only option.