### PR TITLE
Make sure we return after gracefully shutdown

### DIFF
--- a/Sources/ServiceLifecycle/ServiceGroup.swift
+++ b/Sources/ServiceLifecycle/ServiceGroup.swift
@@ -332,6 +332,7 @@ public actor ServiceGroup: Sendable {
                                 group: &group,
                                 gracefulShutdownManagers: gracefulShutdownManagers
                             )
+                            return .success(())
                         } catch {
                             return .failure(error)
                         }
@@ -425,6 +426,7 @@ public actor ServiceGroup: Sendable {
                                 group: &group,
                                 gracefulShutdownManagers: gracefulShutdownManagers
                             )
+                            return .success(())
                         } catch {
                             return .failure(error)
                         }
@@ -451,6 +453,7 @@ public actor ServiceGroup: Sendable {
                             group: &group,
                             gracefulShutdownManagers: gracefulShutdownManagers
                         )
+                        return .success(())
                     } catch {
                         return .failure(error)
                     }

--- a/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
+++ b/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
@@ -320,11 +320,9 @@ final class ServiceGroupTests: XCTestCase {
             await service2.resumeRunContinuation(with: .success(()))
 
             // Waiting to see that the remaining is still running
+            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
             service1.sendPing()
             await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-
-            // The first service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
 
             // Waiting to see that the one remaining are still running
             service1.sendPing()
@@ -523,11 +521,9 @@ final class ServiceGroupTests: XCTestCase {
             await service3.resumeRunContinuation(with: .success(()))
 
             // Waiting to see that the remaining is still running
+            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
             service1.sendPing()
             await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-
-            // The first service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
 
             // Waiting to see that the one remaining are still running
             service1.sendPing()


### PR DESCRIPTION
# Motivation

After calling `shutdownGracefully` in our `ServiceGroup` we know that one of two things happened:
1. We got an error so something went wrong
2. We got no error so all services finished

In the 2. case, there might still be a few child tasks in the task group e.g. the graceful shutdown timeout task. We are currently still iterating the remaining child task results which might lead into unexpected fatal errors.

# Modification
This PR makes sure that after we have successfully shutdown we are stopping iterating the child task results.

# Result
No more unexpected fatal errors.