### PR TITLE
fix ambiguous use of init

### DIFF
--- a/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift
+++ b/Sources/ServiceLifecycle/ServiceGroupConfiguration.swift
@@ -171,19 +171,6 @@ public struct ServiceGroupConfiguration: Sendable {
     ///
     /// - Parameters:
     ///   - services: The groups's service configurations.
-    ///   - logger: The group's logger.
-    public init(
-        services: [ServiceConfiguration],
-        logger: Logger
-    ) {
-        self.services = services
-        self.logger = logger
-    }
-
-    /// Initializes a new ``ServiceGroupConfiguration``.
-    ///
-    /// - Parameters:
-    ///   - services: The groups's service configurations.
     ///   - gracefulShutdownSignals: The signals that lead to graceful shutdown.
     ///   - cancellationSignals: The signals that lead to cancellation.
     ///   - logger: The group's logger.


### PR DESCRIPTION
The following code snippet emits an 'Ambigous use of init' error when using Swift Service Lifecycle v2.3.0:

```swift
let config = ServiceGroupConfiguration(
    services: [],
    logger: logger
)
```

This problem can be hotfixed like this, but it's not the right way:

```swift
let services: [ServiceGroupConfiguration.ServiceConfiguration] = []
let config = ServiceGroupConfiguration(
    services: services,
    logger: logger
)
```

This PR aims to fix the underlying issue in the library itself by removing the unnecessary `init` method, that caused the compiler error. 