### PR TITLE
Make cancelOnGracefulShutdown operations nonescaping

### DIFF
--- a/Sources/ServiceLifecycle/GracefulShutdown.swift
+++ b/Sources/ServiceLifecycle/GracefulShutdown.swift
@@ -74,42 +74,44 @@ enum ValueOrGracefulShutdown<T: Sendable>: Sendable {
 /// Cancels the closure when a graceful shutdown was triggered.
 ///
 /// - Parameter operation: The actual operation.
-public func cancelOnGracefulShutdown<T: Sendable>(_ operation: @Sendable @escaping () async throws -> T) async rethrows -> T? {
-    return try await withThrowingTaskGroup(of: ValueOrGracefulShutdown<T>.self) { group in
-        group.addTask {
-            let value = try await operation()
-            return .value(value)
-        }
-
-        group.addTask {
-            for try await _ in AsyncGracefulShutdownSequence() {
-                return .gracefulShutdown
-            }
-
-            throw CancellationError()
-        }
-
-        let result = try await group.next()
-        group.cancelAll()
-
-        switch result {
-        case .value(let t):
-            return t
-        case .gracefulShutdown:
-            switch try await group.next() {
-            case .value(let t):
-                return t
-            case .gracefulShutdown:
-                fatalError("Unexpectedly got gracefulShutdown from group.next()")
-
-            case nil:
-                fatalError("Unexpectedly got nil from group.next()")
-            }
-
-        case nil:
-            fatalError("Unexpectedly got nil from group.next()")
-        }
-    }
+public func cancelOnGracefulShutdown<T:Sendable>(_ operation: @Sendable () async throws -> T) async rethrows -> T? {
+	return try await withoutActuallyEscaping(operation, do: { operationEscaping in
+		return try await withThrowingTaskGroup(of: ValueOrGracefulShutdown<T>.self) { group in
+			group.addTask {
+				let value = try await operationEscaping()
+				return .value(value)
+			}
+	
+			group.addTask {
+				for try await _ in AsyncGracefulShutdownSequence() {
+					return .gracefulShutdown
+				}
+	
+				throw CancellationError()
+			}
+	
+			let result = try await group.next()
+			group.cancelAll()
+	
+			switch result {
+			case .value(let t):
+				return t
+			case .gracefulShutdown:
+				switch try await group.next() {
+				case .value(let t):
+					return t
+				case .gracefulShutdown:
+					fatalError("Unexpectedly got gracefulShutdown from group.next()")
+	
+				case nil:
+					fatalError("Unexpectedly got nil from group.next()")
+				}
+	
+			case nil:
+				fatalError("Unexpectedly got nil from group.next()")
+			}
+		}
+	})
 }
 
 extension Task where Success == Never, Failure == Never {


### PR DESCRIPTION
Hello.

As of release `v2.4.0`, please consider the following function from the public API.

```
public func cancelOnGracefulShutdown<T: Sendable>(_ operation: @Sendable @escaping () async throws -> T) async rethrows -> T?
```

I was working on a new project today and while architecting the shutdown procedures, I found myself wanting to use this function a lot. Very useful!

Unfortunately, I'm the kind of programmer that gets hopelessly lost in the details and semantics, and this is one of those scenarios where a perfectly valid implementation sits with me as "sub-optimal". Why? Well, I don't really see why this needs to take an escaping operation. In my personal utopian world, this function would work exactly as it is implemented today, simply with a **_non-escaping operation arg_**.

As we know, the primary factor that distinguishes an escaping block and non-escaping block is _when_ the function will be executed. In order to be considered non-escaping, the operation **must** execute within the lifecycle of the function. To my best interpretation, `cancelOnGracefulShutdown` looks to abide by this requirement, despite the compiler being unable to "see" this in the content. Indeed, it appears like this `operation` arg **always** executes within the boundaries of the root function.

As such, I have implemented this proposal to force the nonescaping semantics on this function. I'm no expert of compilers by any stretch of the imagination, but I suspect the compiler will be able to work much more efficiently with memory with the correct knowledge that the `operation` never escapes.