### PR TITLE
`cancelOnGracefulShutdown` hangs, if cancellation is not immediately

### DIFF
--- a/Sources/ServiceLifecycle/AsyncGracefulShutdownSequence.swift
+++ b/Sources/ServiceLifecycle/AsyncGracefulShutdownSequence.swift
@@ -20,7 +20,7 @@
 @usableFromInline
 struct AsyncGracefulShutdownSequence: AsyncSequence, Sendable {
     @usableFromInline
-    typealias Element = Void
+    typealias Element = CancellationWaiter.Reason
 
     @inlinable
     init() {}
@@ -36,9 +36,8 @@ struct AsyncGracefulShutdownSequence: AsyncSequence, Sendable {
         init() {}
 
         @inlinable
-        func next() async throws -> Element? {
-            try await CancellationWaiter().wait()
-            return ()
+        func next() async -> Element? {
+            await CancellationWaiter().wait()
         }
     }
 }

--- a/Sources/ServiceLifecycle/CancellationWaiter.swift
+++ b/Sources/ServiceLifecycle/CancellationWaiter.swift
@@ -16,7 +16,7 @@
 @usableFromInline
 actor CancellationWaiter {
     @usableFromInline
-    enum Reason {
+    enum Reason: Sendable {
         case cancelled
         case gracefulShutdown
     }

--- a/Sources/ServiceLifecycle/CancellationWaiter.swift
+++ b/Sources/ServiceLifecycle/CancellationWaiter.swift
@@ -15,36 +15,38 @@
 /// An actor that provides a function to wait on cancellation/graceful shutdown.
 @usableFromInline
 actor CancellationWaiter {
-    private var taskContinuation: CheckedContinuation<Void, Error>?
+    @usableFromInline
+    enum Reason {
+        case cancelled
+        case gracefulShutdown
+    }
+
+    private var taskContinuation: CheckedContinuation<Reason, Never>?
 
     @usableFromInline
     init() {}
 
     @usableFromInline
-    func wait() async throws {
-        try await withTaskCancellationHandler {
-            try await withGracefulShutdownHandler {
-                try await withCheckedThrowingContinuation { continuation in
+    func wait() async -> Reason {
+        await withTaskCancellationHandler {
+            await withGracefulShutdownHandler {
+                await withCheckedContinuation { (continuation: CheckedContinuation<Reason, Never>) in
                     self.taskContinuation = continuation
                 }
             } onGracefulShutdown: {
                 Task {
-                    await self.finish()
+                    await self.finish(reason: .gracefulShutdown)
                 }
             }
         } onCancel: {
             Task {
-                await self.finish(throwing: CancellationError())
+                await self.finish(reason: .cancelled)
             }
         }
     }
 
-    private func finish(throwing error: Error? = nil) {
-        if let error {
-            self.taskContinuation?.resume(throwing: error)
-        } else {
-            self.taskContinuation?.resume()
-        }
+    private func finish(reason: Reason) {
+        self.taskContinuation?.resume(returning: reason)
         self.taskContinuation = nil
     }
 }

--- a/Sources/ServiceLifecycle/GracefulShutdown.swift
+++ b/Sources/ServiceLifecycle/GracefulShutdown.swift
@@ -123,15 +123,12 @@ public func cancelOnGracefulShutdown<T: Sendable>(_ operation: @Sendable @escapi
         }
 
         group.addTask {
-            for await reason in AsyncGracefulShutdownSequence() {
-                switch reason {
-                case .cancelled:
-                    return .cancelled
-                case .gracefulShutdown:
-                    return .gracefulShutdown
-                }
+            switch await CancellationWaiter().wait() {
+            case .cancelled:
+                return .cancelled
+            case .gracefulShutdown:
+                return .gracefulShutdown
             }
-            fatalError("Unexpectedly didn't exit the task before")
         }
 
         let result = try await group.next()

--- a/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift
+++ b/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift
@@ -404,7 +404,7 @@ final class GracefulShutdownTests: XCTestCase {
     }
 }
 
-func uncancellable(_ closure: @escaping @Sendable () async throws -> ()) async throws {
+func uncancellable(_ closure: @escaping @Sendable () async throws -> Void) async throws {
     let task = Task {
         try await closure()
     }


### PR DESCRIPTION
### Motivation

Currently `cancelOnGracefulShutdown` hangs forever, if cancellation is not immediately but returns a eventually successful result (test case 1: `testCancelOnGracefulShutdownSurvivesCancellation`).
If the Cancellation leads to another error than `CancellationError`, this error is currently not propagated to the user (test case 2: `testCancelOnGracefulShutdownSurvivesErrorThrown`).

### Changes

- `AsyncGracefulShutdownSequence` should never throw as this hides the real errors otherwise
- `CancellationWaiter` should never throw as this hides the real errors otherwise
- Adjustments in `cancelOnGracefulShutdown`

### Result

- `cancelOnGracefulShutdown` works as expected