### PR TITLE
Global cancelOnGracefulShutdown returns non nil value

### DIFF
--- a/Sources/ServiceLifecycle/GracefulShutdown.swift
+++ b/Sources/ServiceLifecycle/GracefulShutdown.swift
@@ -115,7 +115,7 @@ enum ValueOrGracefulShutdown<T: Sendable>: Sendable {
 /// Cancels the closure when a graceful shutdown was triggered.
 ///
 /// - Parameter operation: The actual operation.
-public func cancelOnGracefulShutdown<T: Sendable>(_ operation: @Sendable @escaping () async throws -> T) async rethrows -> T? {
+public func cancelOnGracefulShutdown<T: Sendable>(_ operation: @Sendable @escaping () async throws -> T) async rethrows -> T {
     return try await withThrowingTaskGroup(of: ValueOrGracefulShutdown<T>.self) { group in
         group.addTask {
             let value = try await operation()

--- a/Sources/ServiceLifecycle/GracefulShutdown.swift
+++ b/Sources/ServiceLifecycle/GracefulShutdown.swift
@@ -115,7 +115,7 @@ enum ValueOrGracefulShutdown<T: Sendable>: Sendable {
 /// Cancels the closure when a graceful shutdown was triggered.
 ///
 /// - Parameter operation: The actual operation.
-public func cancelOnGracefulShutdown<T: Sendable>(_ operation: @Sendable @escaping () async throws -> T) async rethrows -> T {
+public func cancelWhenGracefulShutdown<T: Sendable>(_ operation: @Sendable @escaping () async throws -> T) async rethrows -> T {
     return try await withThrowingTaskGroup(of: ValueOrGracefulShutdown<T>.self) { group in
         group.addTask {
             let value = try await operation()
@@ -152,6 +152,11 @@ public func cancelOnGracefulShutdown<T: Sendable>(_ operation: @Sendable @escapi
             fatalError("Unexpectedly got nil from group.next()")
         }
     }
+}
+
+@available(*, deprecated, renamed: "cancelWhenGracefulShutdown")
+public func cancelOnGracefulShutdown<T: Sendable>(_ operation: @Sendable @escaping () async throws -> T) async rethrows -> T? {
+    return try await cancelWhenGracefulShutdown(operation)
 }
 
 extension Task where Success == Never, Failure == Never {

--- a/Sources/ServiceLifecycle/GracefulShutdown.swift
+++ b/Sources/ServiceLifecycle/GracefulShutdown.swift
@@ -154,6 +154,9 @@ public func cancelWhenGracefulShutdown<T: Sendable>(_ operation: @Sendable @esca
     }
 }
 
+/// Cancels the closure when a graceful shutdown was triggered.
+///
+/// - Parameter operation: The actual operation.
 @available(*, deprecated, renamed: "cancelWhenGracefulShutdown")
 public func cancelOnGracefulShutdown<T: Sendable>(_ operation: @Sendable @escaping () async throws -> T) async rethrows -> T? {
     return try await cancelWhenGracefulShutdown(operation)

--- a/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift
+++ b/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift
@@ -215,11 +215,11 @@ final class GracefulShutdownTests: XCTestCase {
         }
     }
 
-    func testCancelOnGracefulShutdown() async throws {
+    func testCancelWhenGracefulShutdown() async throws {
         try await testGracefulShutdown { gracefulShutdownTestTrigger in
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    try await cancelOnGracefulShutdown {
+                    try await cancelWhenGracefulShutdown {
                         try await Task.sleep(nanoseconds: 1_000_000_000_000)
                     }
                 }
@@ -233,9 +233,9 @@ final class GracefulShutdownTests: XCTestCase {
         }
     }
 
-    func testResumesCancelOnGracefulShutdownWithResult() async throws {
+    func testResumesCancelWhenGracefulShutdownWithResult() async throws {
         await testGracefulShutdown { _ in
-            let result = await cancelOnGracefulShutdown {
+            let result = await cancelWhenGracefulShutdown {
                 await Task.yield()
                 return "hello"
             }
@@ -354,11 +354,11 @@ final class GracefulShutdownTests: XCTestCase {
         }
     }
 
-    func testCancelOnGracefulShutdownSurvivesCancellation() async throws {
+    func testCancelWhenGracefulShutdownSurvivesCancellation() async throws {
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
                 await withGracefulShutdownHandler {
-                    await cancelOnGracefulShutdown {
+                    await cancelWhenGracefulShutdown {
                         await OnlyCancellationWaiter().cancellation
 
                         try! await uncancellable {
@@ -374,14 +374,14 @@ final class GracefulShutdownTests: XCTestCase {
         }
     }
 
-    func testCancelOnGracefulShutdownSurvivesErrorThrown() async throws {
+    func testCancelWhenGracefulShutdownSurvivesErrorThrown() async throws {
         struct MyError: Error, Equatable {}
 
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
                 do {
                     try await withGracefulShutdownHandler {
-                        try await cancelOnGracefulShutdown {
+                        try await cancelWhenGracefulShutdown {
                             await OnlyCancellationWaiter().cancellation
 
                             try! await uncancellable {


### PR DESCRIPTION
Issue: https://github.com/swift-server/swift-service-lifecycle/issues/179

`cancelOnGracefulShutdown` has no code paths that return a `nil` value.