### PR TITLE
Support compiling against Musl

### DIFF
--- a/Sources/ConcurrencyHelpers/Lock.swift
+++ b/Sources/ConcurrencyHelpers/Lock.swift
@@ -31,8 +31,10 @@ import Darwin
 #elseif os(Windows)
 import ucrt
 import WinSDK
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 #if os(Windows)

--- a/Sources/UnixSignals/UnixSignal.swift
+++ b/Sources/UnixSignals/UnixSignal.swift
@@ -16,6 +16,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 import Dispatch
 

--- a/Sources/UnixSignals/UnixSignalsSequence.swift
+++ b/Sources/UnixSignals/UnixSignalsSequence.swift
@@ -18,6 +18,9 @@ import Dispatch
 #elseif canImport(Glibc)
 @preconcurrency import Dispatch
 import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Dispatch
+import Musl
 #endif
 import ConcurrencyHelpers
 

--- a/Tests/UnixSignalsTests/UnixSignalTests.swift
+++ b/Tests/UnixSignalsTests/UnixSignalTests.swift
@@ -18,6 +18,8 @@ import XCTest
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 final class UnixSignalTests: XCTestCase {


### PR DESCRIPTION
### Motivation

When building for Linux, we would like to be able to build this package on top of Musl, as well as the usual Glibc.

### Modifications

Conditionally import `Musl` when present, just like we do for `Glibc`.

### Result

Can compile against Musl.