### PR TITLE
Stop using renamed pattern which can cause compiler crash

### DIFF
--- a/Sources/ServiceLifecycle/GracefulShutdown.swift
+++ b/Sources/ServiceLifecycle/GracefulShutdown.swift
@@ -157,7 +157,12 @@ public func cancelWhenGracefulShutdown<T: Sendable>(_ operation: @Sendable @esca
 /// Cancels the closure when a graceful shutdown was triggered.
 ///
 /// - Parameter operation: The actual operation.
+#if compiler(>=6.0)
 @available(*, deprecated, renamed: "cancelWhenGracefulShutdown")
+#else
+// renamed pattern has been shown to cause compiler crashes in 5.x compilers.
+@available(*, deprecated, message: "renamed to cancelWhenGracefulShutdown")
+#endif
 public func cancelOnGracefulShutdown<T: Sendable>(_ operation: @Sendable @escaping () async throws -> T) async rethrows -> T? {
     return try await cancelWhenGracefulShutdown(operation)
 }


### PR DESCRIPTION
Motivation:

Deprecation with rename fixit has been seen to cause compiler crashes in 5.x compiler versions.

Modifications:

Deprecate with message for 5.x compilers.

Result:

Compilation without failure in all scenarios