### PR TITLE
Remove deprecation of withGracefulShutdownHandler if compiler < 6

### DIFF
--- a/Sources/ServiceLifecycle/GracefulShutdown.swift
+++ b/Sources/ServiceLifecycle/GracefulShutdown.swift
@@ -81,7 +81,6 @@ public func withGracefulShutdownHandler<T>(
 #else
 // We need to retain this method with `@_unsafeInheritExecutor` otherwise we will break older
 // Swift versions since the semantics changed.
-@available(*, deprecated, message: "Use the method with the isolation parameter instead.")
 @_disfavoredOverload
 @_unsafeInheritExecutor
 public func withGracefulShutdownHandler<T>(


### PR DESCRIPTION
Currently, if compiler >= 6 then there are 2 implementations. One is deprecated and one is not.
But if compiler is < 6 then there is only one implementation, which is deprecated. I think this was by mistake.