### PR TITLE
Import the Android module if available, since glibc and musl are unavailable on Android

### DIFF
--- a/Sources/ConcurrencyHelpers/Lock.swift
+++ b/Sources/ConcurrencyHelpers/Lock.swift
@@ -35,6 +35,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 #if os(Windows)

--- a/Sources/UnixSignals/UnixSignal.swift
+++ b/Sources/UnixSignals/UnixSignal.swift
@@ -18,6 +18,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 import Dispatch
 

--- a/Sources/UnixSignals/UnixSignalsSequence.swift
+++ b/Sources/UnixSignals/UnixSignalsSequence.swift
@@ -21,6 +21,9 @@ import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Dispatch
 import Musl
+#elseif canImport(Android)
+@preconcurrency import Dispatch
+import Android
 #endif
 import ConcurrencyHelpers
 

--- a/Tests/UnixSignalsTests/UnixSignalTests.swift
+++ b/Tests/UnixSignalsTests/UnixSignalTests.swift
@@ -20,6 +20,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 final class UnixSignalTests: XCTestCase {


### PR DESCRIPTION
I don't expect us to run CI against this until that's more formally supported, but this would greatly help adoption of server-focused packages on Android