### PR TITLE
Add missing availability

### DIFF
--- a/Sources/ServiceLifecycle/ClosureService.swift
+++ b/Sources/ServiceLifecycle/ClosureService.swift
@@ -26,6 +26,7 @@
 /// // Run the service as normal
 /// try await service.run()
 /// ```
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct ClosureService: Service {
     private let closure: @Sendable () async throws -> Void
 

--- a/Tests/ServiceLifecycleTests/ClosureServiceTests.swift
+++ b/Tests/ServiceLifecycleTests/ClosureServiceTests.swift
@@ -17,6 +17,7 @@ import Testing
 
 struct ClosureServiceTests {
     @Test
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func runExecutesClosure() async throws {
         try await confirmation { executed in
             let service = ClosureService {
@@ -27,6 +28,7 @@ struct ClosureServiceTests {
     }
 
     @Test
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func runPropagatesErrors() async {
         struct TestError: Error {}
 


### PR DESCRIPTION
https://github.com/swift-server/swift-service-lifecycle/pull/227 added a `ClosureService`, but we forgot to add availability guards to make sure Swift Concurrency is available.