### PR TITLE
Enable NonisolatedNonsendingByDefault

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,11 +75,13 @@ let package = Package(
 )
 
 for target in package.targets {
-    #if compiler(<6.2)
-    // Needed since Sendable checking with isolated methods is not working correctly before 6.2
     if target.swiftSettings == nil {
         target.swiftSettings = []
     }
+    #if compiler(<6.2)
+    // Needed since Sendable checking with isolated methods is not working correctly before 6.2
     target.swiftSettings?.append(.swiftLanguageMode(.v5))
+    #else
+    target.swiftSettings?.append(.enableUpcomingFeature("NonisolatedNonsendingByDefault"))
     #endif
 }

--- a/Sources/ConcurrencyHelpers/NonSendingIteratorNext.swift
+++ b/Sources/ConcurrencyHelpers/NonSendingIteratorNext.swift
@@ -1,0 +1,20 @@
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension AsyncIteratorProtocol {
+    @usableFromInline
+    package mutating func nonSendingNext() async rethrows -> Element? {
+        guard #available(macOS 15.0, *) else {
+            // On older Apple platforms, we cannot pass through the isolation
+            // That means next() runs on task isolation
+            // That is not safe to the compiler, because the caller of this send function may have called
+            // it concurrently
+            // However, that shouldn't happen in practise since the iterator itself is not Sendable
+
+            nonisolated(unsafe) var this = self
+            defer {
+                self = this
+            }
+            return try await this.next()
+        }
+        return try await self.next(isolation: #isolation)
+    }
+}

--- a/Sources/ConcurrencyHelpers/NonSendingIteratorNext.swift
+++ b/Sources/ConcurrencyHelpers/NonSendingIteratorNext.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftServiceLifecycle open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftServiceLifecycle project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftServiceLifecycle project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncIteratorProtocol {
     @usableFromInline

--- a/Sources/ServiceLifecycle/AsyncCancelOnGracefulShutdownSequence.swift
+++ b/Sources/ServiceLifecycle/AsyncCancelOnGracefulShutdownSequence.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncAlgorithms
+import ConcurrencyHelpers
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence where Self: Sendable, Element: Sendable {
@@ -82,7 +83,7 @@ where Base.Element: Sendable {
                 return nil
             }
 
-            let value = try await self._iterator.next()
+            let value = try await self._iterator.nonSendingNext()
 
             switch value {
             case .base(let element):
@@ -157,7 +158,7 @@ struct AsyncMapNilSequence<Base: AsyncSequence & Sendable>: AsyncSequence, Senda
 
         @inlinable
         mutating func next() async rethrows -> Element? {
-            let value = try await self._iterator.next()
+            let value = try await self._iterator.nonSendingNext()
 
             if let value {
                 return .element(value)

--- a/Sources/ServiceLifecycle/Docs.docc/index.md
+++ b/Sources/ServiceLifecycle/Docs.docc/index.md
@@ -89,5 +89,5 @@ let package = Package(
 
 - ``cancelOnGracefulShutdown(_:)``
 - ``withGracefulShutdownHandler(operation:onGracefulShutdown:)``
-- ``withGracefulShutdownHandler(operation:onGracefulShutdown:)-1x21p``
-- ``withTaskCancellationOrGracefulShutdownHandler(operation:onCancelOrGracefulShutdown:)-81m01``
+- ``withGracefulShutdownHandler(isolation:operation:onGracefulShutdown:)``
+- ``withTaskCancellationOrGracefulShutdownHandler(isolation:operation:onCancelOrGracefulShutdown:)``

--- a/Sources/ServiceLifecycle/ServiceGroup.swift
+++ b/Sources/ServiceLifecycle/ServiceGroup.swift
@@ -885,7 +885,7 @@ public actor ServiceGroup: Sendable, Service {
         group.addTask {
             return await withTaskCancellationHandler {
                 var iterator = channel.makeAsyncIterator()
-                if let addedService = await iterator.next() {
+                if let addedService = await iterator.nonSendingNext() {
                     return .newServiceAdded(addedService)
                 }
 

--- a/Sources/UnixSignals/UnixSignalsSequence.swift
+++ b/Sources/UnixSignals/UnixSignalsSequence.swift
@@ -71,7 +71,7 @@ public struct UnixSignalsSequence: AsyncSequence, Sendable {
         }
 
         public mutating func next() async -> UnixSignal? {
-            return await self.iterator.next()
+            return await self.iterator.nonSendingNext()
         }
     }
 }

--- a/Tests/ServiceLifecycleTests/AsyncCancelOnGracefulShutdownSequenceTests.swift
+++ b/Tests/ServiceLifecycleTests/AsyncCancelOnGracefulShutdownSequenceTests.swift
@@ -36,11 +36,11 @@ final class AsyncCancelOnGracefulShutdownSequenceTests: XCTestCase {
 
                 var iterator = resultStream.makeAsyncIterator()
 
-                await XCTAsyncAssertEqual(await iterator.next(), 1)
+                await XCTAsyncAssertEqual(await iterator.nonSendingNext(), 1)
 
                 gracefulShutdownTrigger.triggerGracefulShutdown()
 
-                await XCTAsyncAssertEqual(await iterator.next(), nil)
+                await XCTAsyncAssertEqual(await iterator.nonSendingNext(), nil)
             }
         }
     }
@@ -61,11 +61,11 @@ final class AsyncCancelOnGracefulShutdownSequenceTests: XCTestCase {
                 var iterator = resultStream.makeAsyncIterator()
                 baseContinuation.yield(1)
 
-                await XCTAsyncAssertEqual(await iterator.next(), 1)
+                await XCTAsyncAssertEqual(await iterator.nonSendingNext(), 1)
 
                 baseContinuation.finish()
 
-                await XCTAsyncAssertEqual(await iterator.next(), nil)
+                await XCTAsyncAssertEqual(await iterator.nonSendingNext(), nil)
             }
         }
     }

--- a/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift
+++ b/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift
@@ -57,8 +57,8 @@ final class GracefulShutdownTests: XCTestCase {
 
         var iterator = stream.makeAsyncIterator()
 
-        await XCTAsyncAssertEqual(await iterator.next(), "onGracefulShutdown")
-        await XCTAsyncAssertEqual(await iterator.next(), "operation")
+        await XCTAsyncAssertEqual(await iterator.nonSendingNext(), "onGracefulShutdown")
+        await XCTAsyncAssertEqual(await iterator.nonSendingNext(), "operation")
     }
 
     func testWithGracefulShutdownHandler_whenNested() async {
@@ -96,15 +96,15 @@ final class GracefulShutdownTests: XCTestCase {
 
                     var iterator = stream.makeAsyncIterator()
 
-                    await XCTAsyncAssertEqual(await iterator.next(), "outerOperation")
-                    await XCTAsyncAssertEqual(await iterator.next(), "innerOperation")
-                    await XCTAsyncAssertEqual(await iterator.next(), "innerOperation")
+                    await XCTAsyncAssertEqual(await iterator.nonSendingNext(), "outerOperation")
+                    await XCTAsyncAssertEqual(await iterator.nonSendingNext(), "innerOperation")
+                    await XCTAsyncAssertEqual(await iterator.nonSendingNext(), "innerOperation")
 
                     gracefulShutdownTestTrigger.triggerGracefulShutdown()
 
-                    await XCTAsyncAssertEqual(await iterator.next(), "outerOnGracefulShutdown")
-                    await XCTAsyncAssertEqual(await iterator.next(), "innerOnGracefulShutdown")
-                    await XCTAsyncAssertEqual(await iterator.next(), "innerOnGracefulShutdown")
+                    await XCTAsyncAssertEqual(await iterator.nonSendingNext(), "outerOnGracefulShutdown")
+                    await XCTAsyncAssertEqual(await iterator.nonSendingNext(), "innerOnGracefulShutdown")
+                    await XCTAsyncAssertEqual(await iterator.nonSendingNext(), "innerOnGracefulShutdown")
                 }
             } onGracefulShutdown: {
                 continuation.yield("outerOnGracefulShutdown")

--- a/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
+++ b/Tests/ServiceLifecycleTests/ServiceGroupTests.swift
@@ -33,7 +33,7 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator = mockService.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .run)
 
             try await XCTAsyncAssertThrowsError(await serviceGroup.run()) {
                 XCTAssertEqual($0 as? ServiceGroupError, .alreadyRunning())
@@ -72,10 +72,10 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator = mockService.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .run)
 
             group.cancelAll()
-            await XCTAsyncAssertEqual(await eventIterator.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .runCancelled)
 
             await mockService.resumeRunContinuation(with: .success(()))
         }
@@ -95,11 +95,11 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator = mockService.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .run)
 
             let pid = getpid()
             kill(pid, UnixSignal.sigalrm.rawValue)  // ignore-unacceptable-language
-            await XCTAsyncAssertEqual(await eventIterator.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .shutdownGracefully)
 
             await mockService.resumeRunContinuation(with: .success(()))
         }
@@ -119,7 +119,7 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator = mockService.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .run)
 
             await mockService.resumeRunContinuation(with: .success(()))
 
@@ -150,13 +150,13 @@ final class ServiceGroupTests: XCTestCase {
 
             var eventIterator1 = service1.events.makeAsyncIterator()
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             await service1.resumeRunContinuation(with: .success(()))
 
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             await service2.resumeRunContinuation(with: .failure(ExampleError()))
 
@@ -182,32 +182,32 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             await service2.resumeRunContinuation(with: .success(()))
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the remaining two are still running
             service1.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // Waiting to see that the remaining is still running
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .shutdownGracefully)
             service1.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
@@ -232,36 +232,36 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             await service3.resumeRunContinuation(with: .success(()))
 
             // The second service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all two are still running
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's exit from the second service
             await service2.resumeRunContinuation(with: .success(()))
 
             // Waiting to see that the remaining is still running
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .shutdownGracefully)
             service1.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // Waiting to see that the one remaining are still running
             service1.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
@@ -283,14 +283,14 @@ final class ServiceGroupTests: XCTestCase {
 
             var shortServiceEventIterator = shortService.events.makeAsyncIterator()
             var longServiceEventIterator = longService.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await shortServiceEventIterator.next(), .run)
-            await XCTAsyncAssertEqual(await longServiceEventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await shortServiceEventIterator.nonSendingNext(), .run)
+            await XCTAsyncAssertEqual(await longServiceEventIterator.nonSendingNext(), .run)
 
             // Finishing the short running service here
             await shortService.resumeRunContinuation(with: .success(()))
 
             // Checking that the long running service is still running
-            await XCTAsyncAssertEqual(await longServiceEventIterator.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await longServiceEventIterator.nonSendingNext(), .runCancelled)
             // Finishing the long running service here
             await longService.resumeRunContinuation(with: .success(()))
 
@@ -318,17 +318,17 @@ final class ServiceGroupTests: XCTestCase {
 
             var service1EventIterator = service1.events.makeAsyncIterator()
             var service2EventIterator = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await service1EventIterator.next(), .run)
-            await XCTAsyncAssertEqual(await service2EventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await service1EventIterator.nonSendingNext(), .run)
+            await XCTAsyncAssertEqual(await service2EventIterator.nonSendingNext(), .run)
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await service1EventIterator.next(), .runPing)
-            await XCTAsyncAssertEqual(await service2EventIterator.next(), .runPing)
+            await XCTAsyncAssertEqual(await service1EventIterator.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await service2EventIterator.nonSendingNext(), .runPing)
 
             // Throwing from service1 here and expect that service2 gets cancelled
             await service1.resumeRunContinuation(with: .failure(ExampleError()))
 
-            await XCTAsyncAssertEqual(await service2EventIterator.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await service2EventIterator.nonSendingNext(), .runCancelled)
             await service2.resumeRunContinuation(with: .success(()))
 
             try await XCTAsyncAssertThrowsError(await group.next()) {
@@ -350,7 +350,7 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator = mockService.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .run)
 
             await mockService.resumeRunContinuation(with: .failure(ExampleError()))
 
@@ -376,38 +376,38 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             await service2.resumeRunContinuation(with: .failure(ExampleError()))
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all two are still running
             service1.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // Waiting to see that the remaining is still running
             service1.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // The first service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the one remaining are still running
             service1.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
@@ -436,36 +436,36 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             await service2.resumeRunContinuation(with: .failure(ExampleError()))
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all two are still running
             service1.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // Waiting to see that the remaining is still running
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .shutdownGracefully)
             service1.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // Waiting to see that the one remaining are still running
             service1.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // Let's throw from this service as well
             struct OtherError: Error {}
@@ -493,20 +493,20 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             let pid = getpid()
             kill(pid, UnixSignal.sigalrm.rawValue)  // ignore-unacceptable-language
 
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runCancelled)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runCancelled)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runCancelled)
 
             // Let's exit from all services
             await service1.resumeRunContinuation(with: .success(()))
@@ -535,33 +535,33 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             let pid = getpid()
             kill(pid, UnixSignal.sigwinch.rawValue)  // ignore-unacceptable-language
 
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all services are still running.
             service1.sendPing()
             service2.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Now we signal cancellation
             kill(pid, UnixSignal.sigalrm.rawValue)  // ignore-unacceptable-language
 
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runCancelled)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runCancelled)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runCancelled)
 
             // Let's exit from all services
             await service1.resumeRunContinuation(with: .success(()))
@@ -589,49 +589,49 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             let pid = getpid()
             kill(pid, UnixSignal.sigalrm.rawValue)  // ignore-unacceptable-language
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all three are still running
             service1.sendPing()
             service2.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the two remaining are still running
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's exit from the middle service
             await service2.resumeRunContinuation(with: .success(()))
 
             // The first service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the one remaining are still running
             service1.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
@@ -655,45 +655,45 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             let pid = getpid()
             kill(pid, UnixSignal.sigalrm.rawValue)  // ignore-unacceptable-language
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all three are still running
             service1.sendPing()
             service2.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the two remaining are still running
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's throw from the middle service
             await service2.resumeRunContinuation(with: .failure(ExampleError()))
 
             // The first service should now receive a cancellation
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runCancelled)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
@@ -725,45 +725,45 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             let pid = getpid()
             kill(pid, UnixSignal.sigalrm.rawValue)  // ignore-unacceptable-language
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all three are still running
             service1.sendPing()
             service2.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the two remaining are still running
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's throw from the middle service
             await service2.resumeRunContinuation(with: .failure(ExampleError()))
 
             // The first service should now receive a cancellation
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .shutdownGracefully)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
@@ -791,45 +791,45 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             let pid = getpid()
             kill(pid, UnixSignal.sigalrm.rawValue)  // ignore-unacceptable-language
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all three are still running
             service1.sendPing()
             service2.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the two remaining are still running
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive a cancellation
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runCancelled)
 
             // Let's exit from the first service
             await service2.resumeRunContinuation(with: .success(()))
@@ -857,47 +857,47 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             let pid = getpid()
             kill(pid, UnixSignal.sigalrm.rawValue)  // ignore-unacceptable-language
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all three are still running
             service1.sendPing()
             service2.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the two remaining are still running
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's throw from the second service
             await service2.resumeRunContinuation(with: .failure(ExampleError()))
 
             // The first service should still be running but seeing a graceful shutdown signal firsts
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .shutdownGracefully)
             service1.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // Let's throw from the first service
             await service1.resumeRunContinuation(with: .failure(ExampleError()))
@@ -944,29 +944,29 @@ final class ServiceGroupTests: XCTestCase {
             var eventIterator2 = service2.events.makeAsyncIterator()
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             let pid = getpid()
             kill(pid, UnixSignal.sigalrm.rawValue)  // ignore-unacceptable-language
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             service1.sendPing()
             service2.sendPing()
 
             // Waiting to see that the two remaining are still running
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's exit from the second service
             await service2.resumeRunContinuation(with: .success(()))
 
             service1.sendPing()
             // Waiting to see that the remaining is still running
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
@@ -987,44 +987,44 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             await serviceGroup.triggerGracefulShutdown()
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all three are still running
             service1.sendPing()
             service2.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the two remaining are still running
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive a cancellation
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runCancelled)
 
             // Let's exit from the first service
             await service2.resumeRunContinuation(with: .success(()))
@@ -1047,13 +1047,13 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator = mockService.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .run)
 
             await serviceGroup.triggerGracefulShutdown()
 
-            await XCTAsyncAssertEqual(await eventIterator.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .shutdownGracefully)
 
-            await XCTAsyncAssertEqual(await eventIterator.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .runCancelled)
 
             try await Task.sleep(for: .seconds(0.2))
 
@@ -1077,11 +1077,11 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator = mockService.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .run)
 
             await serviceGroup.triggerGracefulShutdown()
 
-            await XCTAsyncAssertEqual(await eventIterator.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .shutdownGracefully)
 
             await mockService.resumeRunContinuation(with: .success(()))
 
@@ -1104,13 +1104,13 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator = mockService.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .run)
 
             await serviceGroup.triggerGracefulShutdown()
 
-            await XCTAsyncAssertEqual(await eventIterator.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .shutdownGracefully)
 
-            await XCTAsyncAssertEqual(await eventIterator.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .runCancelled)
 
             try await Task.sleep(for: .seconds(0.2))
 
@@ -1135,11 +1135,11 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator = mockService.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .run)
 
             group.cancelAll()
 
-            await XCTAsyncAssertEqual(await eventIterator.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator.nonSendingNext(), .runCancelled)
 
             try await Task.sleep(for: .seconds(0.1))
 
@@ -1168,48 +1168,48 @@ final class ServiceGroupTests: XCTestCase {
                 }
 
                 var eventIterator1 = service1.events.makeAsyncIterator()
-                await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+                await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
                 var eventIterator2 = service2.events.makeAsyncIterator()
-                await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+                await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
                 var eventIterator3 = service3.events.makeAsyncIterator()
-                await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+                await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
                 await serviceGroup.triggerGracefulShutdown()
 
                 // The last service should receive the shutdown signal first
-                await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+                await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
                 // Waiting to see that all three are still running
                 service1.sendPing()
                 service2.sendPing()
                 service3.sendPing()
-                await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-                await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-                await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
                 // Let's exit from the last service
                 await service3.resumeRunContinuation(with: .success(()))
 
                 // The middle service should now receive the signal
-                await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+                await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
                 // Waiting to see that the two remaining are still running
                 service1.sendPing()
                 service2.sendPing()
-                await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-                await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
                 // Let's exit from the second service
                 await service2.resumeRunContinuation(with: .failure(ExampleError()))
 
                 // The final service should now receive the signal
-                await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
+                await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .shutdownGracefully)
 
                 // Waiting to see that the one remaining are still running
                 service1.sendPing()
-                await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
                 // Let's exit from the first service
                 await service1.resumeRunContinuation(with: .success(()))
@@ -1241,48 +1241,48 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             await serviceGroup.triggerGracefulShutdown()
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all three are still running
             service1.sendPing()
             service2.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the two remaining are still running
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's exit from the second service
             await service2.resumeRunContinuation(with: .failure(ExampleError()))
 
             // The final service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the one remaining are still running
             service1.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
@@ -1310,38 +1310,38 @@ final class ServiceGroupTests: XCTestCase {
                 }
 
                 var eventIterator1 = service1.events.makeAsyncIterator()
-                await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+                await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
                 var eventIterator2 = service2.events.makeAsyncIterator()
-                await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+                await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
                 var eventIterator3 = service3.events.makeAsyncIterator()
-                await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+                await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
                 await serviceGroup.triggerGracefulShutdown()
 
                 // The last service should receive the shutdown signal first
-                await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+                await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
                 // Waiting to see that all three are still running
                 service1.sendPing()
                 service2.sendPing()
                 service3.sendPing()
-                await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-                await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-                await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
                 // Let's exit from the last service
                 await service3.resumeRunContinuation(with: .success(()))
 
                 // The middle service should now receive the signal
-                await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+                await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
                 // Waiting to see that the two remaining are still running
                 service1.sendPing()
                 service2.sendPing()
-                await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-                await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
                 // Let's exit from the first service (even though the second service
                 // is gracefully shutting down)
@@ -1349,7 +1349,7 @@ final class ServiceGroupTests: XCTestCase {
 
                 // Waiting to see that the one remaining are still running
                 service2.sendPing()
-                await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+                await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
                 // Let's exit from the second service
                 await service2.resumeRunContinuation(with: .success(()))
@@ -1382,38 +1382,38 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             await serviceGroup.triggerGracefulShutdown()
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all three are still running
             service1.sendPing()
             service2.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the two remaining are still running
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's exit from the first service (even though the second service
             // is gracefully shutting down)
@@ -1424,7 +1424,7 @@ final class ServiceGroupTests: XCTestCase {
 
             // Waiting to see that the one remaining are still running
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's exit from the second service
             await service2.resumeRunContinuation(with: .success(()))
@@ -1456,44 +1456,44 @@ final class ServiceGroupTests: XCTestCase {
             }
 
             var eventIterator1 = service1.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .run)
 
             var eventIterator2 = service2.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .run)
 
             var eventIterator3 = service3.events.makeAsyncIterator()
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .run)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .run)
 
             await outerServiceGroup.triggerGracefulShutdown()
 
             // The last service should receive the shutdown signal first
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that all three are still running
             service1.sendPing()
             service2.sendPing()
             service3.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator3.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator3.nonSendingNext(), .runPing)
 
             // Let's exit from the last service
             await service3.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive the signal
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .shutdownGracefully)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .shutdownGracefully)
 
             // Waiting to see that the two remaining are still running
             service1.sendPing()
             service2.sendPing()
-            await XCTAsyncAssertEqual(await eventIterator1.next(), .runPing)
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator1.nonSendingNext(), .runPing)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runPing)
 
             // Let's exit from the first service
             await service1.resumeRunContinuation(with: .success(()))
 
             // The middle service should now receive a cancellation
-            await XCTAsyncAssertEqual(await eventIterator2.next(), .runCancelled)
+            await XCTAsyncAssertEqual(await eventIterator2.nonSendingNext(), .runCancelled)
 
             // Let's exit from the first service
             await service2.resumeRunContinuation(with: .success(()))

--- a/Tests/UnixSignalsTests/UnixSignalTests.swift
+++ b/Tests/UnixSignalsTests/UnixSignalTests.swift
@@ -34,7 +34,7 @@ final class UnixSignalTests: XCTestCase {
 
         var signalIterator = signals.makeAsyncIterator()
         kill(pid, signal.rawValue)  // ignore-unacceptable-language
-        let caught = await signalIterator.next()
+        let caught = await signalIterator.nonSendingNext()
         XCTAssertEqual(caught, signal)
     }
 
@@ -47,7 +47,7 @@ final class UnixSignalTests: XCTestCase {
         for _ in 0..<5 {
             kill(pid, signal.rawValue)  // ignore-unacceptable-language
 
-            let caught = await signalIterator.next()
+            let caught = await signalIterator.nonSendingNext()
             XCTAssertEqual(caught, signal)
         }
     }
@@ -108,7 +108,7 @@ final class UnixSignalTests: XCTestCase {
 
         for _ in 0..<10 {
             kill(pid, signal.rawValue)  // ignore-unacceptable-language
-            let trapped = await signalIterator.next()
+            let trapped = await signalIterator.nonSendingNext()
             XCTAssertEqual(trapped, signal)
         }
     }


### PR DESCRIPTION
On swift 6.2, enable NonisolatedNonsendingByDefault

This makes it easier to use the library, especially functions which take closures such as testGracefulShutdown

Changes
- Enable the flag on 6.2
- Shim the iterator.next function to take isolation parameter when platform versions allow