### PR TITLE
Add FreeBSD pthread support to ConcurrencyHelpers/Lock.

### DIFF
--- a/Sources/ConcurrencyHelpers/Lock.swift
+++ b/Sources/ConcurrencyHelpers/Lock.swift
@@ -47,6 +47,9 @@ import wasi_pthread
 #if os(Windows)
 @usableFromInline
 typealias LockPrimitive = SRWLOCK
+#elseif os(FreeBSD) || os(OpenBSD)
+@usableFromInline
+typealias LockPrimitive = pthread_mutex_t?
 #else
 @usableFromInline
 typealias LockPrimitive = pthread_mutex_t
@@ -63,7 +66,11 @@ extension LockOperations {
         #if os(Windows)
         InitializeSRWLock(mutex)
         #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        #if os(FreeBSD) || os(OpenBSD)
+        var attr = pthread_mutexattr_t(bitPattern: 0)
+        #else
         var attr = pthread_mutexattr_t()
+        #endif
         pthread_mutexattr_init(&attr)
 
         let err = pthread_mutex_init(mutex, &attr)


### PR DESCRIPTION
### Motivation

`ConcurrencyHelpers/Lock` has a pthread fallback branch (taken on every
non-Windows / non-Darwin platform) that types `LockPrimitive` as
`pthread_mutex_t` and initializes `pthread_mutexattr_t` with a default
initializer. Both compile on Linux but fail on FreeBSD / OpenBSD, where
those types are opaque-pointer typedefs Swift imports as
`Optional<OpaquePointer>` — the no-argument initializers don't exist.

This blocks swift-service-lifecycle (and everything that depends on
it — Hummingbird, downstream HTTP servers) from compiling on FreeBSD
with the official Swift FreeBSD preview toolchain.

### Modifications

Mirror the pattern landed in [apple/swift-log#387][log-pr]; same change
is being submitted for the sibling NIOLock copies (e.g.
[apple/swift-http-types#123][sht-pr]):

- On `os(FreeBSD) || os(OpenBSD)` alias `LockPrimitive` to
  `pthread_mutex_t?`.
- In `LockOperations.create(_:)`, wrap `pthread_mutexattr_t()` with
  `#if os(FreeBSD) || os(OpenBSD)` to use the `bitPattern:` overload.

[log-pr]: https://github.com/apple/swift-log/pull/387
[sht-pr]: https://github.com/apple/swift-http-types/pull/123

Touches one file (`Sources/ConcurrencyHelpers/Lock.swift`), +7 lines,
all behind FreeBSD/OpenBSD conditionals. No behaviour change on
existing platforms.

### Result

`swift build` and `swift test` both clean on FreeBSD 15.0 with the
official Swift FreeBSD preview toolchain:

```
$ uname -a
FreeBSD swiftbuild 15.0-RELEASE FreeBSD 15.0-RELEASE-p9 releng/15.0-n281048-6d536196f1bd GENERIC amd64

$ swift --version
Swift version 6.3-dev (LLVM 972b62858355d07, Swift 3f8c798cfe25bbb)
Target: x86_64-unknown-freebsd14.3
Build config: +assertions

$ swift build
Building for debugging...
... 276 modules ...
Build complete! (42.62s)

$ swift test
... ClosureServiceTests passed ...
✔ Test run passed.
```

Without this change `ServiceLifecycle` fails to compile on the same
toolchain.

### Checks

- [x] Builds on Linux/Darwin (no change there, all changes guarded
      behind `#if os(FreeBSD) || os(OpenBSD)`).
- [x] Builds + passes existing tests on FreeBSD 15.0 with Swift
      6.3-dev preview toolchain.
- [x] Same pattern as [apple/swift-log#387][log-pr] /
      [apple/swift-http-types#123][sht-pr].
